### PR TITLE
CI-486: ActionController::Redirecting::UnsafeRedirectError triggered on attempting to redirect to herokuapp domain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
     domain_url = ENV['DOMAIN_URL']
     return if domain_url.blank? || request.host_with_port == domain_url
 
-    redirect_to [request.protocol, domain_url, request.fullpath].join
+    redirect_to [request.protocol, domain_url, request.fullpath].join, allow_other_host: true
   end
 end


### PR DESCRIPTION
[![CI-486](https://badgen.net/badge/JIRA/CI-486/0052CC)](https://cloverpop-internship.atlassian.net/browse/CI-486)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[CI-486]: https://cloverpop-internship.atlassian.net/browse/CI-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ