### PR TITLE
CI-484: Shoutout modal is not centered on the Recognition page after clicking the ‘Shoutout’ buttons.

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -751,7 +751,7 @@ input.email-input-new:focus-visible{
   min-width: 925px;
   height:514px;
   top:0;
-  margin-top: 327px;
+  margin-top: 250px;
   overflow-x: hidden;
   .x-close {
     z-index: 31;


### PR DESCRIPTION
[![CI-484](https://badgen.net/badge/JIRA/CI-484/0052CC)](https://cloverpop-internship.atlassian.net/browse/CI-484)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[CI-484]: https://cloverpop-internship.atlassian.net/browse/CI-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ