### PR TITLE
CI-532: The user is redirected to a blank page after clicking the "See the Results" button on the Results email.

### DIFF
--- a/app/javascript/components/Pages/ResultsPage/ResultsPreview.js
+++ b/app/javascript/components/Pages/ResultsPage/ResultsPreview.js
@@ -17,7 +17,7 @@ const ResultsPreview = () => {
   const [loaded, setLoaded] = useState(false)
   const [results, setResults] = useState( [])
   const {answers, emotions, fun_question, gifs, time_periods, sent_shoutouts, received_shoutouts,
-         current_user_shoutouts, current_user} = results
+         current_user_shoutouts, current_user, received_and_public_shoutouts} = results
   const [timePeriod, setTimePeriod] = useState({})
   const params = useParams();
 
@@ -57,7 +57,8 @@ const ResultsPreview = () => {
                          sentShoutouts={sent_shoutouts}
                          receivedShoutouts={received_shoutouts}
                          current_user={current_user}
-                         currentUserShoutouts={current_user_shoutouts} />
+                         currentUserShoutouts={current_user_shoutouts}
+                         recivedPublicShoutouts={received_and_public_shoutouts}/>
         <QuestionSection fun_question={fun_question}
                          answers={answers}
                          current_user={current_user}

--- a/app/presenters/api/v1/results_presenter.rb
+++ b/app/presenters/api/v1/results_presenter.rb
@@ -141,7 +141,7 @@ class Api::V1::ResultsPresenter
 
   def received_and_public_shoutouts
     combined = received_shoutout_blocks + public_shoutout_blocks
-    return nil if combined.empty?
+    return [] if combined.empty?
 
     combined.uniq
   end


### PR DESCRIPTION
[![CI-532](https://badgen.net/badge/JIRA/CI-532/0052CC)](https://cloverpop-internship.atlassian.net/browse/CI-532) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[CI-532]: https://cloverpop-internship.atlassian.net/browse/CI-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ