### PR TITLE
CI-542: The shoutout modal does not open after clicking on Shoutout button if the “Leader Panel” is opened on Results page

### DIFF
--- a/app/javascript/components/Pages/ResultsPageManager/index.js
+++ b/app/javascript/components/Pages/ResultsPageManager/index.js
@@ -16,6 +16,7 @@ import {updateResponse} from "../../requests/axios_requests";
 import Loader from "../../UI/Loader";
 import {MIN_MANAGER_USERS_RESPONSES} from "../../helpers/consts";
 import {changeTimePeriodCallback, loadResultsCallback, scrollTopModalCallback, scrollTopTimePeriodCallback} from "../ResultsPage";
+import ShoutoutModal from "../../UI/ShoutoutModal";
 
 const ResultsManager = ({data, setData, steps = data.response.attributes.steps || [], draft = true}) => {
   const [loaded, setLoaded] = useState(false)
@@ -125,6 +126,11 @@ const ResultsManager = ({data, setData, steps = data.response.attributes.steps |
       </Wrapper>
       <Footer />
     </div>
+    {
+      showModal && <ShoutoutModal onClose = {() => {setShowModal(false)} }
+                                  data={data} setData={setData} />
+
+    }
     <WorkingModal show={showWorkingModal} setShow={setShowWorkingModal}
                   data={data} setData={setData} steps={steps} />
   </Fragment>


### PR DESCRIPTION
[![CI-542](https://badgen.net/badge/JIRA/CI-542/0052CC)](https://cloverpop-internship.atlassian.net/browse/CI-542) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[CI-542]: https://cloverpop-internship.atlassian.net/browse/CI-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ