### PR TITLE
VIB-5: Check of existence the variables from 'View and style' doc in VibeReport app (Variables section)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,6 +435,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -63,3 +63,10 @@ $spacers: (
         7: $spacer * 2,
         8: $spacer * 2.25
 ) ;
+
+$grid-breakpoints: (
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px
+);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -41,13 +41,15 @@ $link-color:                  $navy-blue       !important;
 $link-primary:                $navy-blue       !important;
 
 // Dropdown menu container and contents.
-$dropdown-padding-x:          1rem            !global;
-$dropdown-padding-y:          1rem             !global;
+$dropdown-padding-x:          11px             !global;
+$dropdown-padding-y:          9px              !global;
 $dropdown-spacer:             .625rem          !global;
 $dropdown-bg:                 $gray-100        !global;
 $dropdown-border-color:       $black !global;
 $dropdown-border-width:       1px              !global;
 $dropdown-border-radius:      8px              !global;
+$dropdown-item-padding-y:     5px              !global;
+$dropdown-item-padding-x:     0                !global;
 $dropdown-link-hover-bg:      $gray-100        !global;
 
 // For margin and padding
@@ -64,6 +66,8 @@ $spacers: (
         8: $spacer * 2.25
 ) ;
 
+
+// Breakpoints
 $grid-breakpoints: (
   sm: 576px,
   md: 768px,

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -10,44 +10,21 @@ $border-element:         .1875rem solid $royal-blue;//for intensity elements
 
 // For Typography
 $font-family-base:       'Josefin Sans', sans-serif;
-$font-size-base:          1rem ;
 $line-height-base:        1.2;
-$font-weight-bold:        700;
 $font-weight-semi-bold:   600;
 
 $font-family-italic:      'Josefin Sans Italic', sans-serif;
 $font-family-second:      'Inter', sans-serif;
 
-$h1-font-size:            3rem !important;    //48px
-$h2-font-size:            2.25rem !important; //36px
-//dynamic fonts
-$h3-font-size:            calc($font-size-base * 1.924 + 0.9vw) ;//40px
-$h4-font-size:            calc($font-size-base * 1.424 + 0.9vw) ;//32px
-$h5-font-size:            calc($font-size-base * 0.924 + 0.9vw) ;//24px
-$h6-font-size:            calc($font-size-base * 0.424 + 0.9vw) ;//16px
-
-$font-sizes: (
-1: $h1-font-size,
-2: $h2-font-size,
-3: $h3-font-size,
-4: $h4-font-size,
-5: 1.5rem,
-6: 1rem,
-7: 0.75rem
-) ;
 
 //For input-btn-variables
 $input-btn-padding-y:         1.375rem          !default;//22px
 $input-btn-padding-x:         1.375rem          !default;//22px
-$input-btn-font-family:       null              !default;
-$input-btn-font-size:         $font-size-base   !default;
 $input-btn-line-height:       4.375rem          !default;
 $input-btn-border-width:      .1875rem          !default;
-$input-btn-border-radius:     .9375rem          !default;
 $input-btn-border-color:      $royal-blue       !default;
 
 //For Buttons
-
 $btn-padding-y:               0                !global;
 $btn-padding-x:               .5rem            !global;
 $btn-font-family:             $font-family-base;
@@ -58,25 +35,20 @@ $btn-width-intensity:         7.25rem;//116px
 $btn-height-intensity:        3.4375rem;//55px
 $btn-border-width:            1px              !global;
 $btn-disabled-opacity:        50%              !global;
-$btn-disabled-color:          $white           !important;
 
 // For Links
 $link-color:                  $navy-blue       !important;
 $link-primary:                $navy-blue       !important;
 
 // Dropdown menu container and contents.
-$dropdown-min-width:          260px            !global;
-$dropdown-padding-x:          11px             !global;
-$dropdown-padding-y:          9px              !global;
+$dropdown-padding-x:          1rem            !global;
+$dropdown-padding-y:          1rem             !global;
 $dropdown-spacer:             .625rem          !global;
 $dropdown-bg:                 $gray-100        !global;
-$dropdown-border-color:       1px solid $black !global;
+$dropdown-border-color:       $black !global;
 $dropdown-border-width:       1px              !global;
 $dropdown-border-radius:      8px              !global;
-$dropdown-item-padding-y:     5px              !global;
-$dropdown-item-padding-x:     0                !global;
 $dropdown-link-hover-bg:      $gray-100        !global;
-$dropdown-link-active-bg:     transparent;
 
 // For margin and padding
 $spacer: 2rem ;


### PR DESCRIPTION
[![VIB-5](https://badgen.net/badge/JIRA/VIB-5/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-5) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Description
- Removed unused variables
- Removed variables that have the same value in the bootstrap.
- Set up breakpoints `sm: 576px, md: 768px, lg: 992px, xl: 1200px`

| Variable  | Action | Reason  | 
|---|---|---|
| $font-size-base  | Removed | The same value as bootstrap  | 
| $font-weight-bold  | Removed | The same value as bootstrap  | 
|  $h(1,2,3,4,5,6)-font-size  | Removed | The calculation was performed poorly  | 
| $font-sizes | Removed |  The calculation was performed poorly  |
|$input-btn-font-family| Removed | The same value as bootstrap  |
|$input-btn-font-size| Removed | The same value as bootstrap  |
|$input-btn-border-radius | Removed |  Unused variable  |
|$btn-disabled-color | Removed | Unused variable |
|$dropdown-min-width | Removed | Unused variable|
|$dropdown-border-color | Replaced | Removed value except the color |
|$dropdown-link-active-bg | Removed | Unused variable |