### PR TITLE
VIB-25 Upgrade Gems Proposed by Snyk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,30 +3,30 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.2.6'
 
-gem 'activeadmin', '~> 3.1', '>= 3.1.0'                       # The administration framework for Ruby on Rails
+gem 'activeadmin', '~> 3.2', '>= 3.2.2'                       # The administration framework for Ruby on Rails
 gem 'awesome_print', '~> 1.9', '>= 1.9.2'                     # Nicely formatted data structures in console.
 gem 'bootsnap', require: false                                # Reduces boot times through caching; required in config/boot.rb
 gem 'chartkick', '~> 5.0', '>= 5.0.2'                         # Create beautiful Javascript charts with one line of Ruby
 gem 'cssbundling-rails', '~> 1.2', '>= 1.2.0'                 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
-gem 'devise', '~> 4.9', '>= 4.9.3'                            # Flexible authentication solution for Rails with Warden
-gem 'devise-passwordless', '>= 1.0.0'                         # A passwordless a.k.a. "magic link" login strategy
+gem 'devise', '~> 4.9', '>= 4.9.4'                            # Flexible authentication solution for Rails with Warden
+gem 'devise-passwordless', '>= 1.0.2'                         # A passwordless a.k.a. "magic link" login strategy
 gem 'groupdate', '~> 6.3', '>= 6.3.0'                         # The simplest way to group temporal data
-gem 'jbuilder', '~> 2.11', '>= 2.11.5'                        # Build JSON APIs with ease [https://github.com/rails/jbuilder]
+gem 'jbuilder', '~> 2.12', '>= 2.12.0'                        # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jsbundling-rails', '~> 1.1', '>= 1.1.2'                  # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 gem 'jsonapi-serializer', '~> 2.2'                            # Fast, simple and easy to use JSON:API serialization library (also known as fast_jsonapi).
 gem 'nokogiri'                                                # premailer-rails requires either nokogiri or hpricot.
 gem 'pg', '~> 1.1'                                            # Postgres gem
 gem 'premailer-rails'                                         # gem is a drop in solution for styling HTML emails with CSS without having to do the hard work yourself.
-gem 'puma', '~> 6.4'                                          # Webserver recommended by heroku: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
-gem 'rack-cors', '~> 2.0', '>= 2.0.1'                         # Middleware that will make Rack-based apps CORS compatible. Fork the project here: https://github.com/cyu/rack-cors
+gem 'puma', '~> 6.4', '>= 6.4.2'                                          # Webserver recommended by heroku: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
+gem 'rack-cors', '~> 2.0', '>= 2.0.2'                         # Middleware that will make Rack-based apps CORS compatible. Fork the project here: https://github.com/cyu/rack-cors
 gem 'rails', '~> 7.2.2.1'                                     # Ruby on Rails is a full-stack web framework.
 gem 'redis', '~> 4.0'                                         # A Ruby client that tries to match Redis' API one-to-one
-gem 'rubocop', '~> 1.45', '>= 1.45.1', require: false         # A Ruby static code analyzer https://github.com/bbatsov/rubocop
+gem 'rubocop', '~> 1.58', '>= 1.58.0', require: false         # A Ruby static code analyzer https://github.com/bbatsov/rubocop
 gem 'rubocop-performance', '~> 1.16', require: false          # A rubocop Performance extension
 gem 'rubocop-rails', '~> 2.20', '>= 2.20.0', require: false   # Automatic Rails code style checking tool. A RuboCop extension focused on enforcing Rails best practices and coding conventions.
 gem 'sassc-rails', '~> 2.1', '>= 2.1.2'                       # This gem integrates the C implementation of Sass, LibSass, into the asset pipeline.
 gem 'smarter_csv', '1.9.0'                                    # This gem for smarter importing of CSV Files as Array(s) of Hashes, with optional features for processing large files in parallel.
-gem 'sprockets-rails', '~> 3.4', '>= 3.4.2'                   # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
+gem 'sprockets-rails', '~> 3.5', '>= 3.5.0'                   # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'stimulus-rails', '~> 1.3', '>= 1.3.0'                    # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem 'turbo-rails', '~> 1.5', '>= 1.5.0'                       # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem #A passwordless a.k.a. "magic link" login strategy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,7 +378,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
-    rubocop (1.70.0)
+    rubocop (1.71.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -481,7 +481,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  activeadmin (~> 3.1, >= 3.1.0)
+  activeadmin (~> 3.2, >= 3.2.2)
   annotate
   awesome_print (~> 1.9, >= 1.9.2)
   bootsnap
@@ -490,15 +490,15 @@ DEPENDENCIES
   chartkick (~> 5.0, >= 5.0.2)
   cssbundling-rails (~> 1.2, >= 1.2.0)
   debug
-  devise (~> 4.9, >= 4.9.3)
-  devise-passwordless (>= 1.0.0)
+  devise (~> 4.9, >= 4.9.4)
+  devise-passwordless (>= 1.0.2)
   dotenv-rails (~> 2.1, >= 2.1.1)
   factory_bot_rails
   faker!
   fix-db-schema-conflicts
   git-smart
   groupdate (~> 6.3, >= 6.3.0)
-  jbuilder (~> 2.11, >= 2.11.5)
+  jbuilder (~> 2.12, >= 2.12.0)
   jsbundling-rails (~> 1.1, >= 1.1.2)
   jsonapi-serializer (~> 2.2)
   letter_opener_web
@@ -506,14 +506,14 @@ DEPENDENCIES
   pg (~> 1.1)
   postmark-rails (~> 0.22.1)
   premailer-rails
-  puma (~> 6.4)
-  rack-cors (~> 2.0, >= 2.0.1)
+  puma (~> 6.4, >= 6.4.2)
+  rack-cors (~> 2.0, >= 2.0.2)
   rails (~> 7.2.2.1)
   rails-controller-testing
   redis (~> 4.0)
   rspec-json_expectations
   rspec-rails (>= 6.0.3)
-  rubocop (~> 1.45, >= 1.45.1)
+  rubocop (~> 1.58, >= 1.58.0)
   rubocop-performance (~> 1.16)
   rubocop-rails (~> 2.20, >= 2.20.0)
   sassc-rails (~> 2.1, >= 2.1.2)
@@ -522,7 +522,7 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   smarter_csv (= 1.9.0)
-  sprockets-rails (~> 3.4, >= 3.4.2)
+  sprockets-rails (~> 3.5, >= 3.5.0)
   stimulus-rails (~> 1.3, >= 1.3.0)
   turbo-rails (~> 1.5, >= 1.5.0)
   tzinfo-data


### PR DESCRIPTION
[![VIB-25](https://badgen.net/badge/JIRA/VIB-25/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-25) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review this PR

1 Update the following gems in the Gemfile to the recommended versions:
gem 'activeadmin' from 3.1.0 to 3.2.2
gem 'devise' from 4.9.3 to 4.9.4
gem 'devise-passwordless' from 1.0.1 to 1.0.2
gem 'jbuilder'  from 2.11.5 to 2.12.0
gem 'puma'  from 6.4.0 to 6.4.2
gem 'rack-cors' from 2.0.1 to 2.0.2
gem 'rubocop' 1.57.2 to 1.58.0
gem 'sprockets-rails'  from 3.4.2 to 3.5.0

2 Manual testing completed successfully