### PR TITLE
VIB-8 Refactor Emotion Entry for mobile-friendly layout

### DIFF
--- a/app/assets/stylesheets/emition_entry.scss
+++ b/app/assets/stylesheets/emition_entry.scss
@@ -1,24 +1,21 @@
 @import "colors";
 @import "design_system_vibereport";
 
-h1.emotion-entry{
-  margin-bottom: 32px !important;
-}
-
 h4.emotion-entry {
   font-weight: 400;
   color: $gray-600;
 }
 
 .input-new-word{
-  width: 700px;
   border-radius: 15px;
   font-size: 40px;
   height: auto;
   padding: 2px 12px;
 
   &::placeholder{
-    font-size: 36px;
+    font-size: clamp(25px, 4vw, 36px);
     font-weight: 700;
+    max-width: 100%;
   }
 }
+

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -965,6 +965,7 @@ a.dropdown-item{
 .btn-group.wrap-toggle{
   height: 130px;
   width: 370px;
+  max-width: 100%;
   background-color: $color-grey;
   border-radius: 100px;
   box-shadow: 0 4px 4px 0 $gray-250;

--- a/app/javascript/components/Pages/EmotionEntry.js
+++ b/app/javascript/components/Pages/EmotionEntry.js
@@ -71,30 +71,40 @@ const EmotionEntry = ({
         steps={steps}
         draft={draft}
       >
-        <div className="central-element">
-          <h1 className="emotion-entry">A new one! What’s up?</h1>
-          <h4 className="mt-3 text-gray-600">
-            What word best describes work, recently?
-          </h4>
-          <Form.Control
-            className={`${emotionClasses[selectedType]} email_field input-new-word mb-80 border-royal-blue`}
-            type="text"
-            maxLength={15}
-            autoComplete="off"
-            placeholder="Add a new word"
-            name="word"
-            value={emotion.word || ''}
-            onChange={onChangeEmotion}
-          />
-          <ToggleEmotionType
-            selectedType={selectedType}
-            handleEmotionType={handleEmotionType}
-          />
+      <div className="container-fluid">
+        <div className="row flex-column justify-content-center">
+          <div className="col-12 text-center mx-auto">
+            <h1 className="my-1 my-md-2">A new one! What’s up?</h1>
+            <h4 className="my-1 my-md-2 text-gray-600">
+              What word best describes work, recently?
+            </h4>
+          </div>
+          <div className="col-12 col-lg-6 col-md-8 mx-auto">
+            <Form.Control
+              className={`${emotionClasses[selectedType]} email_field input-new-word mb-5 mb-md-8 border-royal-blue`}
+              type="text"
+              maxLength={15}
+              autoComplete="off"
+              placeholder="Add a new word"
+              name="word"
+              value={emotion.word || ''}
+              onChange={onChangeEmotion}
+            />
+          </div>
+          <div className="col-12 col-md-6 mb-4 mx-auto">
+            <ToggleEmotionType
+              selectedType={selectedType}
+              handleEmotionType={handleEmotionType}
+            />
+          </div>
+          <div className="d-flex gap-3 flex-column flex-sm-row">
+            <BlockLowerBtns
+              nextHandling={handlingOnClickNext}
+              disabled={emotion.word.length < 2}
+            />
+          </div>
         </div>
-        <BlockLowerBtns
-          nextHandling={handlingOnClickNext}
-          disabled={emotion.word.length < 2}
-        />
+      </div>
       </Layout>
     )
   );


### PR DESCRIPTION
[![VIB-8](https://badgen.net/badge/JIRA/VIB-8/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-8) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Description**
This PR enhances the Emotion Entry page to make it fully responsive and mobile-friendly. Adjustments have been made to ensure all UI elements adapt seamlessly across various screen sizes without compromising the design.

- Introduced responsive width and height rules for the input field and toggle elements.
- Replaced hardcoded font sizes with clamp() for scalable placeholder text.
- Added max-width constraints to toggle groups for better alignment on smaller screens.
- Updated structure to use container-fluid and Bootstrap grid classes  for responsive alignment.

Please, review the screenshot to see the laptop and mobile versions:

Laptop - Emotion Entry page
![image](https://github.com/user-attachments/assets/b04c6e85-acde-4860-8c27-dabd62a63e99)

Tablet- Emotion Entry page
![image](https://github.com/user-attachments/assets/dc13ed6d-3a97-4ba6-abe9-b83cbea2e249)

Mobile- Emotion Entry page
![image](https://github.com/user-attachments/assets/43d8339d-f7e9-4399-97d4-e4f3aa3cd2cc)

How to test:
- Check that the page is displayed correctly on all screen sizes (desktop, tablet, mobile).
- Check for reduced placeholder text size on narrower screens.
- Check the toggle button's response to pressing and the correct selection of the active button.
- Make sure that the color change is correct when choosing toggle buttons.
- Check the correct placement of the next and back buttons.