### PR TITLE
VIB-54 Add randomized string into route for Project records syncing URL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   username: postgres
-  password: 5347409
+  password: 
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   username: postgres
-  password: 
+  password: 5347409
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,22 +47,21 @@ Rails.application.routes.draw do
       get '/result', to: 'results#show'
       get '/unsubscribe', to: 'users#unsubscribe'
       get '/result_manager', to: 'results#show'
-      post '/projects', to: 'projects#sync'
+      # Dynamically sets the route for project codes sync based on the ENV key for security
+      auth_key = ENV['TIMESHEET_PROJECT_SYNC_AUTH_KEY']
+    
+      if auth_key.present?
+        post "projects/#{auth_key}", to: 'projects#sync'
+      else
+        post 'projects', to: 'projects#sync'
+      end
+    
+      get '*path', to: 'home#app', constraints: lambda { |req|
+        req.path.exclude? 'rails/active_storage'
+      }
     end
   end
 
-  # Dynamically sets the route for project codes sync based on the ENV key for security
-  auth_key = ENV['TIMESHEET_PROJECT_SYNC_AUTH_KEY']
-
-  if auth_key.present?
-    post "project_codes/#{auth_key}", to: 'project_codes#sync'
-  else
-    post 'project_codes', to: 'project_codes#sync'
-  end
-
-  get '*path', to: 'home#app', constraints: lambda { |req|
-    req.path.exclude? 'rails/active_storage'
-  }
 
   root to: 'home#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,12 +56,12 @@ Rails.application.routes.draw do
         post '/projects', to: 'projects#sync'
       end
     
-      get '*path', to: 'home#app', constraints: lambda { |req|
-        req.path.exclude? 'rails/active_storage'
-      }
     end
   end
-
+  
+  get '*path', to: 'home#app', constraints: lambda { |req|
+    req.path.exclude? 'rails/active_storage'
+  }
 
   root to: 'home#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,16 @@ Rails.application.routes.draw do
       get '/result_manager', to: 'results#show'
     end
   end
+
+  # Dynamically sets the route for project codes sync based on the ENV key for security
+  auth_key = ENV['TIMESHEET_PROJECT_SYNC_AUTH_KEY']
+
+  if auth_key.present?
+    post "project_codes/#{auth_key}", to: 'project_codes#sync'
+  else
+    post 'project_codes', to: 'project_codes#sync'
+  end
+
   get '*path', to: 'home#app', constraints: lambda { |req|
     req.path.exclude? 'rails/active_storage'
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,9 +51,9 @@ Rails.application.routes.draw do
       auth_key = ENV['TIMESHEET_PROJECT_SYNC_AUTH_KEY']
     
       if auth_key.present?
-        post "projects/#{auth_key}", to: 'projects#sync'
+        post "/projects/#{auth_key}", to: 'projects#sync'
       else
-        post 'projects', to: 'projects#sync'
+        post '/projects', to: 'projects#sync'
       end
     
       get '*path', to: 'home#app', constraints: lambda { |req|

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -135,5 +135,31 @@ RSpec.describe Api::V1::ProjectsController, type: :request do
         expect(Project.find_by(code: 'NEW-001')).to be_nil
       end
     end
+
+
+    
+    context 'TIMESHEET_PROJECT_SYNC_AUTH_KEY is set in ENV' do
+      let(:auth_key) { 'test_sync_key' }
+      let(:valid_payload) do
+        {
+          projects: [
+            { company: 'Company A', code: 'PRJ-001', name: 'Project Alpha' },
+            { company: 'Company B', code: 'PRJ-002', name: 'Project Beta' }
+          ]
+        }.to_json
+      end
+
+      before do
+        allow(ENV).to receive(:[]).with('TIMESHEET_PROJECT_SYNC_AUTH_KEY').and_return(auth_key)
+        Rails.application.reload_routes! 
+      end
+
+      it 'syncs projects successfully when auth_key is correct' do
+        post "/api/v1/projects/#{auth_key}", params: valid_payload, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['message']).to eq('Projects synchronized successfully!')
+      end
+    end
   end
 end


### PR DESCRIPTION
[![VIB-54](https://badgen.net/badge/JIRA/VIB-54/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-54) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Description**
This PR introduces a dynamic route for syncing project codes, making the path configurable via an environment variable (TIMESHEET_PROJECT_SYNC_AUTH_KEY). This enhances security by allowing the sync URL to be changed without modifying the code.
- If the environment variable is set, the route includes the auth key (/project_codes/:auth_key).
- If it's not set, the default route (/project_codes) is used.

Changes Implemented:
- Added a conditional route in routes.rb that dynamically assigns the sync path based on ENV['TIMESHEET_PROJECT_SYNC_AUTH_KEY'].
- Ensured that the correct route is registered using rails routes.
- Verified that the environment variable correctly affects the route structure.

After the review is completed base branch has to be changed to VIB-68