### PR TITLE
VIB-74: Removal of Help Ticket Code and Database Table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,6 @@ class User < ApplicationRecord
   has_many :fun_questions, dependent: :destroy
   has_many :fun_question_answers, dependent: :destroy
   has_many :mentions, through: :shoutout_recipients, source: :shoutout
-  has_many :notifications, dependent: :destroy
   has_many :user_teams, dependent: :destroy
   has_many :teams, through: :user_teams
   has_many :emojis, dependent: :destroy

--- a/db/migrate/20250214101305_drop_notifications.rb
+++ b/db/migrate/20250214101305_drop_notifications.rb
@@ -1,0 +1,14 @@
+class DropNotifications < ActiveRecord::Migration[7.2]
+  def up
+    drop_table :notifications, if_exists: true
+  end
+
+  def down
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :details
+      t.boolean :viewed, null: false, default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2023_10_17_173020) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_14_101305) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,15 +82,6 @@ ActiveRecord::Schema[7.2].define(version: 2023_10_17_173020) do
     t.index ["question_body"], name: "index_fun_questions_on_question_body", unique: true
     t.index ["time_period_id"], name: "index_fun_questions_on_time_period_id"
     t.index ["user_id"], name: "index_fun_questions_on_user_id"
-  end
-
-  create_table "notifications", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.text "details"
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.boolean "viewed", default: false, null: false
-    t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 
   create_table "responses", force: :cascade do |t|
@@ -194,7 +185,6 @@ ActiveRecord::Schema[7.2].define(version: 2023_10_17_173020) do
   add_foreign_key "fun_question_answers", "users"
   add_foreign_key "fun_questions", "time_periods"
   add_foreign_key "fun_questions", "users"
-  add_foreign_key "notifications", "users"
   add_foreign_key "responses", "emotions"
   add_foreign_key "responses", "fun_question_answers"
   add_foreign_key "responses", "fun_questions"


### PR DESCRIPTION
[![VIB-74](https://badgen.net/badge/JIRA/VIB-74/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-74) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review this PR.

1) To remove the database table used to store Help tickets was created migration:
- step 1: rails generate migration DropNotifications
- step 2: update migration file
- step 3: rails db:migrate
2) updated file app/models/user.rb
3) All models, controllers, views, and API endpoints related to Help tickets were removed in VIB-73