### PR TITLE
VIB-92: Remove or fix "Comments" tab from Active Admin

### DIFF
--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -331,7 +331,6 @@ ActiveAdmin.register Team do
         end
       end
     end
-    active_admin_comments
   end
 
   controller do

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -125,7 +125,7 @@ ActiveAdmin.setup do |config|
   # This allows your users to comment on any resource registered with Active Admin.
   #
   # You can completely disable comments:
-  # config.comments = false
+  config.comments = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'

--- a/db/migrate/20250221120414_drop_active_admin_comments.rb
+++ b/db/migrate/20250221120414_drop_active_admin_comments.rb
@@ -1,0 +1,16 @@
+class DropActiveAdminComments < ActiveRecord::Migration[7.2]
+  def up
+    drop_table :active_admin_comments
+  end
+
+  def down
+    create_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.references :resource, polymorphic: true
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+    add_index :active_admin_comments, [:namespace]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,23 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_14_101305) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_21_120414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "active_admin_comments", force: :cascade do |t|
-    t.bigint "author_id"
-    t.string "author_type"
-    t.text "body"
-    t.datetime "created_at", null: false
-    t.string "namespace"
-    t.bigint "resource_id"
-    t.string "resource_type"
-    t.datetime "updated_at", null: false
-    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author"
-    t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource"
-  end
 
   create_table "admin_users", force: :cascade do |t|
     t.datetime "created_at", null: false


### PR DESCRIPTION
[![VIB-92](https://badgen.net/badge/JIRA/VIB-92/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-92) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review this PR.

1) Set the value for config.comments = false in the config/initializers/active_admin.rb file.
2) Removed active_admin_comments where it was used.
3) Created a migration using rails generate migration DropActiveAdminComments.
4) Verified that the Comments tab is not active.

![image](https://github.com/user-attachments/assets/81b2f037-268e-4479-b622-035fe4f34804)
