### PR TITLE
VIB-94: Word bubbles do not adjust for long emotion words on the Emotion-selection page using app in the tablet and mobile views

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -75,7 +75,7 @@
       height: 2rem;
       border-radius: 15px;
       box-shadow: $btn-box-shadow;
-      min-width: 7.3rem;
+      min-width: 8rem;
       margin: 5px 0;
       max-width: 175px;
       overflow: hidden;

--- a/app/assets/stylesheets/design_system_vibereport.scss
+++ b/app/assets/stylesheets/design_system_vibereport.scss
@@ -32,10 +32,6 @@ h1 {
   font-size: 2rem !important; //32px
 }
 
-.wb1 {
-  font-size: 1.25rem !important; //20px
-}
-
 // Use for regular buttons
 .c1 {
   font: {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -798,3 +798,7 @@ input:checked + .slider-shoutout img {
 .max-width-sign-in-input {
   max-width: 660px;
 }
+
+.max-width-emotion-selection {
+  max-width: 720px;
+}

--- a/app/javascript/components/Footer.js
+++ b/app/javascript/components/Footer.js
@@ -6,7 +6,7 @@ const Footer = ({ data, setData, hideShoutout, numShoutouts }) => {
   const location = useLocation();
   const isRecognitionPage = location.pathname.match("recognition");
 
-  return <footer className='d-flex justify-content-between p-1 w-100 align-items-center'>
+  return <footer className='d-flex p-1 w-100 justify-content-end'>
     {!isRecognitionPage && <ShoutoutButton data={data} setData={setData} hideShoutout={hideShoutout} num={numShoutouts} />}
   </footer>
 };

--- a/app/javascript/components/Pages/ListEmotions.js
+++ b/app/javascript/components/Pages/ListEmotions.js
@@ -106,83 +106,77 @@ function ListEmotions({
     >
       {!!error && <p>{error.message}</p>}
       {!isLoading && !error && (
-        <div className="col-12 col-md-10 col-lg-8 mx-auto">
-          <div className="container-fluid">
-            <div className="row justify-content-center">
-              <div className="col-12 col-md-auto mb-3 d-flex">
-                <div className="calendar-complete-by">
-                  <div className="data">{rangeFormat(timePeriod)}</div>
-                </div>
-              </div>
-              <div className="col-12 col-sm w-75">
-                <div className="pb-3 fs-5 text-gray-700">
-                  Time for your latest check-in!
-                </div>
-                <div className="lh-1 text-black fs-3 fs-md-1">
-                  What word best describes how you feel about work?
-                </div>
-              </div>
-            </div>
+        <div className="d-flex">
+          <div className="calendar-complete-by mt-lg-8 me-lg-4 mt-0 me-0">
+            <div className="data">{rangeFormat(timePeriod)}</div>
           </div>
-          <div className="py-1 col-8 col-md-9 col-lg-10 col-xl-8 mx-auto">
-            <div className="row justify-content-center">
-              {emotions.map((emotion, index) => (
-                <div
-                  key={emotion.id}
-                  className="col-6 col-md-3 d-flex justify-content-center"
-                >
-                  <ButtonEmotion
+          <div className="mx-auto max-width-emotion-selection">
+            <div className="pb-3 fs-5 text-gray-700">
+              Time for your latest check-in!
+            </div>
+            <div className="lh-1 text-black fs-3 fs-md-1">
+              What word best describes how you feel about work?
+            </div>
+            <div className="py-1 mx-auto">
+              <div className="row justify-content-center mx-auto">
+                {emotions.map((emotion, index) => (
+                  <div
                     key={emotion.id}
-                    category={emotions[index].attributes.category}
-                    onClick={() =>
-                      clickHandling(
-                        emotions[index].attributes.word,
-                        emotions[index].id
-                      )
-                    }
+                    className="col-6 col-md-3 d-flex justify-content-center"
                   >
-                    {emotions[index].attributes.word}
-                  </ButtonEmotion>
-                </div>
-              ))}
+                    <ButtonEmotion
+                      key={emotion.id}
+                      category={emotions[index].attributes.category}
+                      onClick={() =>
+                        clickHandling(
+                          emotions[index].attributes.word,
+                          emotions[index].id
+                        )
+                      }
+                    >
+                      {emotions[index].attributes.word}
+                    </ButtonEmotion>
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-          <div className="w-75 border-bottom border-3 border-light mx-auto"></div>
-          <div className="d-flex flex-column">
-            <div className="d-flex py-1 gap-2">
-              <Button
-                className="btn btn-bubbles neutral wb1 not-standart"
-                onClick={() => setIsShuffleEmotions(true)}
-              >
-                Show me different words
-              </Button>
-              <Button
-                className="btn btn-bubbles neutral wb1 not-standart"
-                onClick={notSayHandling}
-              >
-                I'd rather not say...
-              </Button>
+            <div className="w-75 border-bottom border-3 border-light mx-auto"></div>
+            <div className="d-flex flex-column">
+              <div className="d-flex py-1 gap-2">
+                <Button
+                  className="btn btn-bubbles neutral wb1 fs-6 fw-bold not-standart"
+                  onClick={() => setIsShuffleEmotions(true)}
+                >
+                  Show me different words
+                </Button>
+                <Button
+                  className="btn btn-bubbles neutral wb1 fs-6 fw-bold not-standart"
+                  onClick={notSayHandling}
+                >
+                  I'd rather not say...
+                </Button>
+              </div>
+              <div className="w-50 border-bottom border-3 border-light mx-auto"></div>
             </div>
-            <div className="w-50 border-bottom border-3 border-light mx-auto"></div>
-          </div>
-          <div className="text-center d-flex flex-column justify-content-center">
-            <div className="py-1 fs-5 text-gray-700 mx-auto">
-              Share it in your own words!
-            </div>
-            <div className="d-flex mx-auto">
-              <BtnAddYourOwnWord
-                content="Add your own word"
-                onClick={ownWordHandling}
-              />
-            </div>
-            <div className="d-flex mx-auto py-2">
-              <NavLink
-                className="mx-auto my-1 fs-5"
-                onClick={onClickNotWorking}
-                to={''}
-              >
-                I was not working recently
-              </NavLink>
+            <div className="text-center d-flex flex-column justify-content-center">
+              <div className="py-1 fs-5 text-gray-700 mx-auto">
+                Share it in your own words!
+              </div>
+              <div className="d-flex mx-auto">
+                <BtnAddYourOwnWord
+                  content="Add your own word"
+                  onClick={ownWordHandling}
+                />
+              </div>
+              <div className="d-flex mx-auto py-2">
+                <NavLink
+                  className="mx-auto my-1 fs-5"
+                  onClick={onClickNotWorking}
+                  to={''}
+                >
+                  I was not working recently
+                </NavLink>
+              </div>
             </div>
           </div>
         </div>

--- a/app/javascript/components/Pages/ListEmotions.js
+++ b/app/javascript/components/Pages/ListEmotions.js
@@ -106,8 +106,8 @@ function ListEmotions({
     >
       {!!error && <p>{error.message}</p>}
       {!isLoading && !error && (
-        <div className="d-flex">
-          <div className="calendar-complete-by mt-lg-8 me-lg-4 mt-0 me-0">
+        <div className="d-flex flex-column flex-lg-row me-0 me-lg-10">
+          <div className="calendar-complete-by mt-lg-8 me-lg-4 mt-0 mx-auto">
             <div className="data">{rangeFormat(timePeriod)}</div>
           </div>
           <div className="mx-auto max-width-emotion-selection">

--- a/app/javascript/components/Pages/ResultsPage/GifSection.js
+++ b/app/javascript/components/Pages/ResultsPage/GifSection.js
@@ -25,7 +25,7 @@ const GifSection = ({gifs, nextTimePeriod, isMinUsersResponses}) => {
   const gifItems = gifs.sort((a, b) => a.image.height - b.image.height).map((gif, index) => {
     return <div className='col align-items-center p-1 gif-container' key={index}>
       <Tippy content={<div
-        className={`btn btn-bubbles wb1 not-shadow tippy ${gif.emotion.category}`}>{gif.emotion.word}</div>}>
+        className={`btn btn-bubbles wb1 fs-6 not-shadow tippy ${gif.emotion.category}`}>{gif.emotion.word}</div>}>
         <img src={gif.image.src} className="img-fluid" alt={`gif ${index}`}/>
       </Tippy>
     </div>

--- a/app/javascript/components/UI/ButtonEmotion.js
+++ b/app/javascript/components/UI/ButtonEmotion.js
@@ -7,7 +7,7 @@ const ButtonEmotion = (props) => {
   }
 
   return (
-      <button type='button' className={`btn btn-bubbles wb1 fw-bold ${props.category}`} onClick={clickHandling}>
+      <button type='button' className={`btn btn-bubbles wb1 fw-bold fs-sm-6 fs-7 ${props.category}`} onClick={clickHandling}>
         {props.children}
       </button>
   );

--- a/app/javascript/components/UI/ShoutoutButton.js
+++ b/app/javascript/components/UI/ShoutoutButton.js
@@ -21,7 +21,7 @@ const ShoutoutButton = ({ data, setData,  num = 0, isMove = false, hideShoutout}
     setShoutOutForm(true)
   }
 
-  const style = isMove ? `left-bottom-corner ${ isMove && ('into-centerX' + (!num ? '2_5' : '')) } ${blink}` : 'hud shoutout'
+  const style = isMove ? `left-bottom-corner ${ isMove && ('into-centerX' + (!num ? '2_5' : '')) } ${blink}` : ''
 
   return (
     <div>


### PR DESCRIPTION
[![VIB-94](https://badgen.net/badge/JIRA/VIB-94/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-94) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello team, please review PR

## Description
- Updated emotion selection page layout with max-width to align it with staging version
- Fixed font size for bubble words on small screens

## Examples:
1440px
<img width="1059" alt="Screenshot 2025-02-26 at 01 10 24" src="https://github.com/user-attachments/assets/076fdc2b-f15d-4c0f-84f5-0636c8511964" />
320px
<img width="238" alt="Screenshot 2025-02-26 at 01 09 57" src="https://github.com/user-attachments/assets/d3d24402-35e2-41e6-b7ae-ecaa6d22a0e0" />