### PR TITLE
VIB-101: [Outlook] Certain elements are not displayed in Emails for web view

### DIFF
--- a/app/views/layouts/_logo.erb
+++ b/app/views/layouts/_logo.erb
@@ -2,7 +2,7 @@
 <table role="presentation" width="100%">
   <tr>
     <td style="text-align: center;">
-      <img src="<%= asset_path('logo.png') %>" alt="Logo" height="<%= #{height} %>" width="auto" style="display: block; margin: 0 auto; border: 0;">
+      <img src="<%= asset_path('logo.png') %>" alt="Logo" height="<%= height %>" width="auto" style="display: block; margin: 0 auto; border: 0;">
     </td>
   </tr>
 </table>

--- a/app/views/layouts/_logo.erb
+++ b/app/views/layouts/_logo.erb
@@ -2,7 +2,7 @@
 <table role="presentation" width="100%">
   <tr>
     <td style="text-align: center;">
-      <img src="<%= asset_path('logo.png') %>" alt="Logo" height="<%= height %>" width="auto" style="display: block; margin: 0 auto; border: 0;">
+      <img src="<%= asset_path('logo.png') %>" alt="Logo" height="<%= #{height} %>" width="auto" style="display: block; margin: 0 auto; border: 0;">
     </td>
   </tr>
 </table>

--- a/app/views/layouts/_logo.erb
+++ b/app/views/layouts/_logo.erb
@@ -2,7 +2,7 @@
 <table role="presentation" width="100%">
   <tr>
     <td style="text-align: center;">
-      <img src="logo.png" alt="Logo" height="#{height}px" width="auto" style="display: block; margin: 0 auto;">
+      <img src="<%= asset_path('logo.png') %>" alt="Logo" height="<%= height %>" width="auto" style="display: block; margin: 0 auto; border: 0;">
     </td>
   </tr>
 </table>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Settings for external email services such as Mailtrap or Postmark
-  config.action_mailer.asset_host = "http://#{ENV['DOMAIN_URL']}"
+  config.action_mailer.asset_host = "https://#{ENV['DOMAIN_URL']}"
   config.action_mailer.default_url_options = { host: ENV['DOMAIN_URL'], protocol: 'https' }
   if ENV['POSTMARK_API_TOKEN'].present?
     config.action_mailer.delivery_method = :postmark


### PR DESCRIPTION
[![VIB-101](https://badgen.net/badge/JIRA/VIB-101/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-101) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review PR

## Description
- In production.rb, `config.action_mailer.asset_host` was set to `http://#{ENV['DOMAIN_URL']}`.
Outlook web and Windows most probably upgraded to stricter security policies and were breaking on HTTP asset URLs, while other clients most probably silently upgraded or ignored the mismatch. Switching to `https://#{ENV['DOMAIN_URL']} `
- Replaced `<img src="logo.png">` it with `<%= asset_path('logo.png') %>` ensures the full URL is used for images

## Testing example from Outlook Web
<img width="1504" alt="Screenshot 2025-03-07 at 10 13 21" src="https://github.com/user-attachments/assets/32e65266-7b3f-4c55-9233-55d5e1e120d3" />


