### PR TITLE
VIB-104: Shoutout preview does not truncate on Recognition page after entering messages over 40 characters

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -166,6 +166,18 @@
   overflow-x: hidden;
 }
 
+@media (max-width: 575.98px) {
+  .field-shout-outs {
+    max-width: 400px;
+  }
+}
+
+@media (max-width: 420px) {
+  .field-shout-outs {
+    max-width: 290px;
+  }
+}
+
 
 //system scroll
 .field-shout-outs,

--- a/app/javascript/components/Pages/Recognition.js
+++ b/app/javascript/components/Pages/Recognition.js
@@ -70,12 +70,12 @@ const Recognition = ({data, setData, saveDataToDb, steps, service, draft}) => {
 
   const output = (shoutOuts) => {
     return (
-        <ul className="d-flex d-sm-flex flex-column gap-2 py-2 list-unstyled">
+        <ul className="d-flex flex-column gap-2 py-2 list-unstyled">
           {shoutOuts.map(shoutOut => (
               <li
-                  className="bg-light position-relative align-middle border rounded-4 border-4 border-primary p-1 text-break pe-10"
+                  className="bg-light position-relative align-middle border rounded-4 border-4 border-primary p-1 text-break pe-10 w-100"
                   key={shoutOut.id}>
-                <p className="text-start fs-7 fs-sm-5 fs-md-4 fw-semibold m-0">{parse(
+                <p className="text-start fs-7 fs-sm-5 fs-md-4 fw-semibold m-0 text-truncate">{parse(
                     shoutOut.rich_text)}</p>
                 <div
                     className="position-absolute top-50 end-0 translate-middle-y d-flex">
@@ -155,7 +155,7 @@ const Recognition = ({data, setData, saveDataToDb, steps, service, draft}) => {
                                    setData={setData}
                                    editObj={shoutOutForm.editObj}/>}
                 <div
-                    className="container justify-content-center border border-4 rounded-4 border-primary field-shout-outs">
+                    className="container justify-content-center border border-4 rounded-4 border-primary field-shout-outs w-100">
                   {output(shoutOuts)}
                 </div>
                 <p className="m-0 mt-4 fs-8 fs-md-7">Any more shoutouts to


### PR DESCRIPTION
[![VIB-104](https://badgen.net/badge/JIRA/VIB-104/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-104) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review PR

## Description
- Added `text-truncate` bootstrap utility class
- Added media query for screens smaller than _576px_. Because the native Bootstrap `container` is not setting it for small screens and `text-truncate` requires a fixed width, I did it with the help of a media query

## Screenshot examples
Mobile
<img width="418" alt="Screenshot 2025-03-11 at 15 32 48" src="https://github.com/user-attachments/assets/3c1b437a-984c-4197-b6ff-821f38d2c8b6" />
Desktop
<img width="1041" alt="Screenshot 2025-03-11 at 15 31 44" src="https://github.com/user-attachments/assets/77138b17-e012-4f1d-93f4-448bc9ff697d" />