### PR TITLE
VIB-121: [Outlook]Certain elements in invite, check-in, and results emails do not match design specs when viewed in web view

### DIFF
--- a/app/assets/stylesheets/email_page.css
+++ b/app/assets/stylesheets/email_page.css
@@ -126,7 +126,7 @@ Here styles for:
     text-decoration: none;
     height: 31px;
     font-size: 18px; /* Fallback */
-    font-size: clamp(18px, 2vw, 20px) !important;
+    font-size: clamp(18px, 2vw, 20px);
 }
 
 .positive-a:hover, .neutral-a:hover, .negative-a:hover {
@@ -265,7 +265,7 @@ Here styles for:
     max-width: 453px;
     height: 55px;
     font-size: 24px; /* Fallback */
-    font-size: clamp(20px, 2vw, 24px) !important;
+    font-size: clamp(20px, 2vw, 24px);
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
     margin: 0 auto;
@@ -299,7 +299,7 @@ Here styles for:
     width: 100%;
     max-width: 735px;
     font-size: 32px; /* Fallback */
-    font-size: clamp(32px, 2vw, 40px) !important;
+    font-size: clamp(32px, 2vw, 40px);
     line-height: 1;
     margin: 0 auto;
     color: #000000;
@@ -307,7 +307,7 @@ Here styles for:
 
 .lnk-was-not a {
     font-size: 20px; /* Fallback */
-    font-size: clamp(20px, 2vw, 23px) !important;
+    font-size: clamp(20px, 2vw, 23px);
     white-space: nowrap;
     text-decoration-line: underline;
     line-height: normal;
@@ -365,7 +365,7 @@ Here styles for:
     max-width: 378px;
     height: 19px;
     font-size: 24px; /* Fallback */
-    font-size: clamp(20px, 2vw, 24px) !important;
+    font-size: clamp(20px, 2vw, 24px);
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
     margin: 18px auto 14px auto;
@@ -397,7 +397,7 @@ Here styles for:
     display: inline-block;
     padding: 13px 23px 13px 23px;
     font-size: 30px; /* Fallback */
-    font-size: clamp(30px, 2vw, 36px) !important;
+    font-size: clamp(30px, 2vw, 36px);
     line-height: 1;
     color: rgba(0, 0, 0, 0.6);
     border: 3px solid #5689EB;
@@ -416,7 +416,7 @@ Here styles for:
 
 .lnk-unsubscribe a {
     font-size: 16px; /* Fallback */
-    font-size: clamp(12px, 2vw, 16px) !important;
+    font-size: clamp(12px, 2vw, 16px);
     line-height: 1;
     color: #4D4D4D;
     text-decoration: underline;

--- a/app/assets/stylesheets/email_page.css
+++ b/app/assets/stylesheets/email_page.css
@@ -244,7 +244,7 @@ Here styles for:
     text-align: left;
     width: 102px;
     height: 115px;
-    margin-top: 20px;
+    margin: 20px 0 10px 0;
     background-image: url("complete-by.png");
     background-repeat: no-repeat;
     background-size: contain;

--- a/app/assets/stylesheets/email_page.css
+++ b/app/assets/stylesheets/email_page.css
@@ -113,8 +113,7 @@ Here styles for:
 
 .positive, .neutral, .negative {
     height: 31px;
-    font-size: 16px; /* Fallback */
-    font-size: clamp(14px, 2vw, 19px);
+    font-size: 18px;
     line-height: 1;
     text-align: center;
     cursor: pointer;
@@ -125,8 +124,7 @@ Here styles for:
     font-weight: bold;
     text-decoration: none;
     height: 31px;
-    font-size: 18px; /* Fallback */
-    font-size: clamp(18px, 2vw, 20px);
+    font-size: 20px;
 }
 
 .positive-a:hover, .neutral-a:hover, .negative-a:hover {
@@ -264,8 +262,7 @@ Here styles for:
     width: 100%;
     max-width: 453px;
     height: 55px;
-    font-size: 24px; /* Fallback */
-    font-size: clamp(20px, 2vw, 24px);
+    font-size: 24px;
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
     margin: 0 auto;
@@ -304,15 +301,8 @@ Here styles for:
     color: #000000;
 }
 
-@media (max-width: 767.98px) {
-    .question {
-        font-size: 32px;
-    }
-}
-
 .lnk-was-not a {
-    font-size: 20px; /* Fallback */
-    font-size: clamp(20px, 2vw, 23px);
+    font-size: 23px;
     white-space: nowrap;
     text-decoration-line: underline;
     line-height: normal;
@@ -339,8 +329,7 @@ Here styles for:
 .btn-emotion {
     min-width: 100px;
     height: 31px;
-    font-size: 16px; /* Fallback */
-    font-size: clamp(12px, 2vw, 16px);
+    font-size: 16px;
     line-height: 1.2;
     cursor: pointer;
     box-shadow: 4px 6px 4px rgba(0, 0, 0, 0.25);
@@ -369,8 +358,7 @@ Here styles for:
     width: 100%;
     max-width: 378px;
     height: 19px;
-    font-size: 24px; /* Fallback */
-    font-size: clamp(20px, 2vw, 24px);
+    font-size: 24px;
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
     margin: 18px auto 14px auto;
@@ -401,8 +389,7 @@ Here styles for:
 .big-btn-text a {
     display: inline-block;
     padding: 13px 23px 13px 23px;
-    font-size: 30px; /* Fallback */
-    font-size: clamp(30px, 2vw, 36px);
+    font-size: 36px;
     line-height: 1;
     color: rgba(0, 0, 0, 0.6);
     border: 3px solid #5689EB;
@@ -420,8 +407,7 @@ Here styles for:
 }
 
 .lnk-unsubscribe a {
-    font-size: 16px; /* Fallback */
-    font-size: clamp(12px, 2vw, 16px);
+    font-size: 16px;
     line-height: 1;
     color: #4D4D4D;
     text-decoration: underline;
@@ -611,8 +597,7 @@ html {
     padding-top: 48px;
     width: 115px;
     height: 105px;
-    font-size: 16px; /* Fallback */
-    font-size: clamp(14px, 2vw, 16px);
+    font-size: 16px;
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
     white-space: nowrap;

--- a/app/assets/stylesheets/email_page.css
+++ b/app/assets/stylesheets/email_page.css
@@ -298,11 +298,16 @@ Here styles for:
 .question {
     width: 100%;
     max-width: 735px;
-    font-size: 32px; /* Fallback */
-    font-size: clamp(32px, 2vw, 40px);
+    font-size: 40px;
     line-height: 1;
     margin: 0 auto;
     color: #000000;
+}
+
+@media (max-width: 767.98px) {
+    .question {
+        font-size: 32px;
+    }
 }
 
 .lnk-was-not a {

--- a/app/assets/stylesheets/email_page.css
+++ b/app/assets/stylesheets/email_page.css
@@ -113,6 +113,7 @@ Here styles for:
 
 .positive, .neutral, .negative {
     height: 31px;
+    font-size: 16px; /* Fallback */
     font-size: clamp(14px, 2vw, 19px);
     line-height: 1;
     text-align: center;
@@ -124,6 +125,7 @@ Here styles for:
     font-weight: bold;
     text-decoration: none;
     height: 31px;
+    font-size: 18px; /* Fallback */
     font-size: clamp(18px, 2vw, 20px) !important;
 }
 
@@ -262,6 +264,7 @@ Here styles for:
     width: 100%;
     max-width: 453px;
     height: 55px;
+    font-size: 24px; /* Fallback */
     font-size: clamp(20px, 2vw, 24px) !important;
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
@@ -295,6 +298,7 @@ Here styles for:
 .question {
     width: 100%;
     max-width: 735px;
+    font-size: 32px; /* Fallback */
     font-size: clamp(32px, 2vw, 40px) !important;
     line-height: 1;
     margin: 0 auto;
@@ -302,6 +306,7 @@ Here styles for:
 }
 
 .lnk-was-not a {
+    font-size: 20px; /* Fallback */
     font-size: clamp(20px, 2vw, 23px) !important;
     white-space: nowrap;
     text-decoration-line: underline;
@@ -329,6 +334,7 @@ Here styles for:
 .btn-emotion {
     min-width: 100px;
     height: 31px;
+    font-size: 16px; /* Fallback */
     font-size: clamp(12px, 2vw, 16px);
     line-height: 1.2;
     cursor: pointer;
@@ -358,6 +364,7 @@ Here styles for:
     width: 100%;
     max-width: 378px;
     height: 19px;
+    font-size: 24px; /* Fallback */
     font-size: clamp(20px, 2vw, 24px) !important;
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
@@ -389,6 +396,7 @@ Here styles for:
 .big-btn-text a {
     display: inline-block;
     padding: 13px 23px 13px 23px;
+    font-size: 30px; /* Fallback */
     font-size: clamp(30px, 2vw, 36px) !important;
     line-height: 1;
     color: rgba(0, 0, 0, 0.6);
@@ -407,6 +415,7 @@ Here styles for:
 }
 
 .lnk-unsubscribe a {
+    font-size: 16px; /* Fallback */
     font-size: clamp(12px, 2vw, 16px) !important;
     line-height: 1;
     color: #4D4D4D;
@@ -597,6 +606,7 @@ html {
     padding-top: 48px;
     width: 115px;
     height: 105px;
+    font-size: 16px; /* Fallback */
     font-size: clamp(14px, 2vw, 16px);
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);

--- a/app/assets/stylesheets/email_page.css
+++ b/app/assets/stylesheets/email_page.css
@@ -219,10 +219,6 @@ Here styles for:
     text-align: left;
 }
 
-.ml-55 {
-    margin-left: 55px;
-}
-
 .mt-10 {
     margin-top: 10px;
 }
@@ -244,7 +240,7 @@ Here styles for:
     text-align: left;
     width: 102px;
     height: 115px;
-    margin: 20px 0 10px 0;
+    margin-top: 20px;
     background-image: url("complete-by.png");
     background-repeat: no-repeat;
     background-size: contain;

--- a/app/assets/stylesheets/email_page.css
+++ b/app/assets/stylesheets/email_page.css
@@ -124,7 +124,7 @@ Here styles for:
     font-weight: bold;
     text-decoration: none;
     height: 31px;
-    font-size: clamp(18px, 2vw, 20px);
+    font-size: clamp(18px, 2vw, 20px) !important;
 }
 
 .positive-a:hover, .neutral-a:hover, .negative-a:hover {
@@ -262,7 +262,7 @@ Here styles for:
     width: 100%;
     max-width: 453px;
     height: 55px;
-    font-size: clamp(20px, 2vw, 24px);
+    font-size: clamp(20px, 2vw, 24px) !important;
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
     margin: 0 auto;
@@ -295,14 +295,14 @@ Here styles for:
 .question {
     width: 100%;
     max-width: 735px;
-    font-size: clamp(32px, 2vw, 40px);
+    font-size: clamp(32px, 2vw, 40px) !important;
     line-height: 1;
     margin: 0 auto;
     color: #000000;
 }
 
 .lnk-was-not a {
-    font-size: clamp(20px, 2vw, 23px);
+    font-size: clamp(20px, 2vw, 23px) !important;
     white-space: nowrap;
     text-decoration-line: underline;
     line-height: normal;
@@ -358,7 +358,7 @@ Here styles for:
     width: 100%;
     max-width: 378px;
     height: 19px;
-    font-size: clamp(20px, 2vw, 24px);
+    font-size: clamp(20px, 2vw, 24px) !important;
     line-height: 1;
     color: rgba(0, 0, 0, 0.7);
     margin: 18px auto 14px auto;
@@ -389,7 +389,7 @@ Here styles for:
 .big-btn-text a {
     display: inline-block;
     padding: 13px 23px 13px 23px;
-    font-size: clamp(30px, 2vw, 36px);
+    font-size: clamp(30px, 2vw, 36px) !important;
     line-height: 1;
     color: rgba(0, 0, 0, 0.6);
     border: 3px solid #5689EB;
@@ -407,7 +407,7 @@ Here styles for:
 }
 
 .lnk-unsubscribe a {
-    font-size: clamp(12px, 2vw, 16px);
+    font-size: clamp(12px, 2vw, 16px) !important;
     line-height: 1;
     color: #4D4D4D;
     text-decoration: underline;

--- a/app/views/user_email_mailer/reminder_email.html.erb
+++ b/app/views/user_email_mailer/reminder_email.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>Email letter</title>
-  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
-  <style>
+  <head>
+    <title>Email letter</title>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
+    <style>
       * {
           margin: 0;
           padding: 0;
@@ -33,54 +33,54 @@
           padding: 10px 10px !important;
         }
       }
-  </style>
-  <%= stylesheet_link_tag 'email_page' , media: 'all' %>
-</head>
-<body>
-<div class="board mx-auto">
-  <!--[if mso]>
-  <table role="presentation" width="100%">
-    <tr>
-      <td class="first-row-reminder" style="height: 8px; text-align: left;">
-         <table class="calendar" role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 102px; height: 115px; background-image: url('complete-by.png'); background-repeat: no-repeat; background-size: contain;">
+    </style>
+    <%= stylesheet_link_tag 'email_page' , media: 'all' %>
+  </head>
+  <body>
+    <div class="board mx-auto">
+      <!--[if mso]>
+        <table role="presentation" width="100%">
           <tr>
-            <td class="data" style="padding-top: 55px; width: 102px; height: 14px; font-size: 16px; line-height: 17px; color: rgba(0, 0, 0, 0.7); white-space: nowrap; text-transform: capitalize;">
-              <%= @view_calendar_days = "#{@time_period.end_date.strftime('%d %b')}".html_safe %>
+            <td class="first-row-reminder" style="height: 8px; text-align: left;">
+              <table class="calendar" role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 102px; height: 115px; background-image: url('complete-by.png'); background-repeat: no-repeat; background-size: contain;">
+                <tr>
+                  <td class="data" style="padding-top: 55px; width: 102px; height: 14px; font-size: 16px; line-height: 17px; color: rgba(0, 0, 0, 0.7); white-space: nowrap; text-transform: capitalize;">
+                    <%= @view_calendar_days = "#{@time_period.end_date.strftime('%d %b')}".html_safe %>
+                  </td>
+                </tr>
+              </table>
             </td>
           </tr>
         </table>
-      </td>
-    </tr>
-  </table>
-  <![endif]-->
-  <!--[if !mso]><!-->
+      <![endif]-->
+      <!--[if !mso]><!-->
   <div class="first-row-reminder">
     <div class="calendar">
       <div class="data"><%= @view_calendar_days = "#{@time_period.end_date.strftime('%d %b')}".html_safe %></div>
     </div>
   </div>
   <!--<![endif]-->
-  <div>
-    <div class="second-row-reminder">
-      <div class="mx-auto">
-        <%= render 'layouts/logo', height: 61 %>
-      </div>
-    </div>
-    <div class="mx-auto third-row-magic mt-40">
-      <div class="mx-auto greeting">Your check-in progress is saved</div>
-    </div>
-    <div class="mx-auto fourth-row-magic">
-      <div class="submit-annotation text-reminder mx-auto">Come on back when you’re ready to complete your check-in</div>
-    </div>
-    <div class="big-btn mx-auto mt-40">
-      <div class="big-btn-text mx-auto">
-        <%= link_to "Back to check-in", { controller: 'api/v1/responses',
+        <div>
+          <div class="second-row-reminder">
+            <div class="mx-auto">
+              <%= render 'layouts/logo', height: 61 %>
+            </div>
+          </div>
+          <div class="mx-auto third-row-magic mt-40">
+            <div class="mx-auto greeting">Your check-in progress is saved</div>
+          </div>
+          <div class="mx-auto fourth-row-magic">
+            <div class="submit-annotation text-reminder mx-auto">Come on back when you’re ready to complete your check-in</div>
+          </div>
+          <div class="big-btn mx-auto mt-40">
+            <div class="big-btn-text mx-auto" style="font-size: 1.875rem;>
+              <%= link_to "Back to check-in", { controller: 'api/v1/responses',
                                           action: 'sign_in_from_email',
                                           id: @time_period.id,
                                           user_id: @user.id }%>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
-</div>
-</body>
-</html>
+    </body>
+  </html>

--- a/app/views/user_email_mailer/reminder_email.html.erb
+++ b/app/views/user_email_mailer/reminder_email.html.erb
@@ -73,7 +73,7 @@
             <div class="submit-annotation text-reminder mx-auto">Come on back when you’re ready to complete your check-in</div>
           </div>
           <div class="big-btn mx-auto mt-40">
-            <div class="big-btn-text mx-auto" style="font-size: 1.875rem;>
+            <div class="big-btn-text mx-auto">
               <%= link_to "Back to check-in", { controller: 'api/v1/responses',
                                           action: 'sign_in_from_email',
                                           id: @time_period.id,

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -102,36 +102,36 @@
           }
 
           .question {
-              font-size: 32px;
+              font-size: 32px !important;
               line-height: 2rem;
           }
 
           .lnk-unsubscribe a {
-            font-size: 12px;
+            font-size: 12px !important;
           }
 
           .big-btn-text a {
-            font-size: 30px;
+            font-size: 30px !important;
           }
 
           .big-btn-tooltip {
-            font-size: 20px;
+            font-size: 20px !important;
           }
 
           .btn-emotion {
-            font-size: 12px;
+            font-size: 12px !important;
           }
 
           .positive-a, .neutral-a, .negative-a {
-            font-size: 18px;
+            font-size: 18px !important;
           }
 
           .positive, .neutral, .negative {
-            font-size: 14px;
+            font-size: 14px !important;
           }
 
           .gap {
-            margin-top: 10px;
+            margin-top: 10px !important;
           }
       }
     </style>
@@ -174,7 +174,7 @@
               <% (0..3).each do |col| %>
                 <% cell = @table[(row * 4 + col)] %>
                 <div class="<%= "btn-emotion #{cell.category}" %>"
-               style="min-width: <%= btn_special(cell.word, :width)%>px; margin: 5px <%= btn_special(cell.word, :margin)%>px; padding: 6px 0 5px 0; line-height: 1;">
+               style="min-width: <%= btn_special(cell.word, :width)%>px; margin: 5px <%= btn_special(cell.word, :margin)%>px; padding: 8px 0; line-height: 1;">
                   <% @link_for_emotion[:emotion_id] = cell.id %>
                   <%= link_to cell.word, @link_for_emotion, class: "#{cell.category}-a" %>
                 </div>
@@ -185,12 +185,12 @@
         <div class="underline_list"></div>
         <div class='neutral-area' style="padding: 10px 0;">
           <div class="neutral-btns" style="display: flex">
-            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1;">
+            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 8px 0; line-height: 1;">
               <%= link_to "Show me different words", { controller: 'api/v1/responses',
                                                  action: 'sign_in_from_email',
                                                  user_id: @user.id }, class: "neutral-a" %>
             </div>
-            <div class="<%= "btn-emotion neutral gap" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1;">
+            <div class="<%= "btn-emotion neutral gap" %>" style="width: 260px; margin: 0 auto; padding: 8px 0; line-height: 1;">
               <%= link_to "I'd rather not say...", @link_for_not_say, class: "neutral-a" %>
             </div>
           </div>

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>Email letter</title>
-  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
+  <head>
+    <title>Email letter</title>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
       * {
           margin: 0;
           padding: 0;
@@ -104,83 +104,83 @@
               line-height: 2rem;
           }
       }
-  </style>
-  <%= stylesheet_link_tag 'email_page', media: 'all' %>
-</head>
-<body>
-<div class="board mx-auto">
-  <div class="first-row">
-    <div class="mx-auto my-0">
-      <%= render 'layouts/logo', height: 61 %>
-    </div>
-  </div>
-  <!--[if mso]>
-  <table role="presentation" width="100%">
-    <tr>
-      <td class="second-row" style="height: 50px; text-align: left;">
-        <table class="calendar" role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 105px; height: 120px; background-image: url('complete-by.png'); background-repeat: no-repeat; background-size: contain;">
+    </style>
+    <%= stylesheet_link_tag 'email_page', media: 'all' %>
+  </head>
+  <body>
+    <div class="board mx-auto">
+      <div class="first-row">
+        <div class="mx-auto my-0">
+          <%= render 'layouts/logo', height: 61 %>
+        </div>
+      </div>
+      <!--[if mso]>
+        <table role="presentation" width="100%">
           <tr>
-            <td class="data" style="padding-top: 55px; width: 105px; height: 14px; font-size: 16px; line-height: 17px; color: rgba(0, 0, 0, 0.7); white-space: nowrap; text-transform: capitalize;">
-              <%= @view_complete_by %>
+            <td class="second-row" style="height: 50px; text-align: left;">
+              <table class="calendar" role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 105px; height: 120px; background-image: url('complete-by.png'); background-repeat: no-repeat; background-size: contain;">
+                <tr>
+                  <td class="data" style="padding-top: 55px; width: 105px; height: 14px; font-size: 16px; line-height: 17px; color: rgba(0, 0, 0, 0.7); white-space: nowrap; text-transform: capitalize;">
+                    <%= @view_complete_by %>
+                  </td>
+                </tr>
+              </table>
             </td>
           </tr>
         </table>
-      </td>
-    </tr>
-  </table>
-  <![endif]-->
-  <!--[if !mso]><!-->
+      <![endif]-->
+      <!--[if !mso]><!-->
   <div class="second-row">
     <div class="calendar ml-55">
       <div class="data"><%= @view_complete_by %></div>
     </div>
   </div>
   <!--<![endif]-->
-  <div class="mx-auto my-0 invitation">Time for your latest check-in!</div>
-  <div class="mx-auto my-0 question">What word best describes how you feel about work?</div>
-  <div class="emotions-container">
-    <% (0..5).each do |row| %>
-      <div class="emotions d-flex">
-        <% (0..3).each do |col| %>
-          <% cell = @table[(row * 4 + col)] %>
-          <div class="<%= "btn-emotion #{cell.category}" %>"
-               style="min-width: <%= btn_special(cell.word, :width)%>px; margin: 5px <%= btn_special(cell.word, :margin)%>px; padding: 5px 0; line-height: 1;">
-            <% @link_for_emotion[:emotion_id] = cell.id %>
-            <%= link_to cell.word, @link_for_emotion, class: "#{cell.category}-a" %>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
-  <div class="underline_list"></div>
-  <div class='neutral-area' style="padding: 10px 0;">
-    <div class="neutral-btns" style="display: flex">
-      <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 5px 0; line-height: 1;">
-        <%= link_to "Show me different words", { controller: 'api/v1/responses',
+        <div class="mx-auto my-0 invitation" style="font-size: 1.5rem;">Time for your latest check-in!</div>
+        <div class="mx-auto my-0 question" style="font-size: 2rem;">What word best describes how you feel about work?</div>
+        <div class="emotions-container">
+          <% (0..5).each do |row| %>
+            <div class="emotions d-flex">
+              <% (0..3).each do |col| %>
+                <% cell = @table[(row * 4 + col)] %>
+                <div class="<%= "btn-emotion #{cell.category}" %>"
+               style="min-width: <%= btn_special(cell.word, :width)%>px; margin: 5px <%= btn_special(cell.word, :margin)%>px; padding: 6px 0 5px 0; line-height: 1;">
+                  <% @link_for_emotion[:emotion_id] = cell.id %>
+                  <%= link_to cell.word, @link_for_emotion, class: "#{cell.category}-a" %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+        <div class="underline_list"></div>
+        <div class='neutral-area' style="padding: 10px 0;">
+          <div class="neutral-btns" style="display: flex">
+            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1; font-size: 1.25rem">
+              <%= link_to "Show me different words", { controller: 'api/v1/responses',
                                                  action: 'sign_in_from_email',
                                                  user_id: @user.id }, class: "neutral-a" %>
-      </div>
-      <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 5px 0; line-height: 1;">
-        <%= link_to "I'd rather not say...", @link_for_not_say, class: "neutral-a" %>
-      </div>
-    </div>
-  </div>
-  <div class="big-btn-tooltip mx-auto">Share it in your own words!</div>
-  <div class="big-btn mx-auto">
-    <div class="big-btn-text">
-      <%= link_to "Add your own word", @link_for_own_word %>
-    </div>
-  </div>
-  <div class="links-container">
-    <div class="lnk-unsubscribe" style="text-align: left">
-      <%= link_to "Unsubscribe from future check-ins", { controller: "api/v1/users",
+            </div>
+            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1; font-size: 1.25rem">
+              <%= link_to "I'd rather not say...", @link_for_not_say, class: "neutral-a" %>
+            </div>
+          </div>
+        </div>
+        <div class="big-btn-tooltip mx-auto" style="font-size: 1.5rem;">Share it in your own words!</div>
+        <div class="big-btn mx-auto">
+          <div class="big-btn-text" style="font-size: 1.875rem;">
+            <%= link_to "Add your own word", @link_for_own_word %>
+          </div>
+        </div>
+        <div class="links-container">
+          <div class="lnk-unsubscribe" style="text-align: left; font-size: 1rem;">
+            <%= link_to "Unsubscribe from future check-ins", { controller: "api/v1/users",
                                                          action: "unsubscribe",
                                                          user_id: @user.id } %>
-    </div>
-    <div class="lnk-was-not" style="width: max-content">
-      <%= link_to "I was not working recently", @link_for_was_not %>
-    </div>
-  </div>
-</div>
-</body>
-</html>
+          </div>
+          <div class="lnk-was-not" style="width: max-content;  font-size: 1.5rem;">
+            <%= link_to "I was not working recently", @link_for_was_not %>
+          </div>
+        </div>
+      </div>
+    </body>
+  </html>

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -73,6 +73,7 @@
 
           .neutral-btns {
               flex-direction: column;
+              gap: 10px !important;
           }
 
           .lnk-was-not a {
@@ -97,11 +98,40 @@
               display: block;
               text-align: center;
               margin-top: 15px;
+              font-size: 20px;
           }
 
           .question {
-              font-size: 2rem;
+              font-size: 32px;
               line-height: 2rem;
+          }
+
+          .lnk-unsubscribe a {
+            font-size: 12px;
+          }
+
+          .big-btn-text a {
+            font-size: 30px;
+          }
+
+          .big-btn-tooltip {
+            font-size: 20px;
+          }
+
+          .btn-emotion {
+            font-size: 12px;
+          }
+
+          .positive-a, .neutral-a, .negative-a {
+            font-size: 18px;
+          }
+
+          .positive, .neutral, .negative {
+            font-size: 14px;
+          }
+
+          .gap {
+            margin-top: 10px;
           }
       }
     </style>
@@ -136,7 +166,7 @@
     </div>
   </div>
   <!--<![endif]-->
-        <div class="mx-auto my-0 invitation" style="font-size: 24px;">Time for your latest check-in!</div>
+        <div class="mx-auto my-0 invitation">Time for your latest check-in!</div>
         <div class="mx-auto my-0 question">What word best describes how you feel about work?</div>
         <div class="emotions-container">
           <% (0..5).each do |row| %>
@@ -155,29 +185,29 @@
         <div class="underline_list"></div>
         <div class='neutral-area' style="padding: 10px 0;">
           <div class="neutral-btns" style="display: flex">
-            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1; font-size: 1.25rem">
+            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1;">
               <%= link_to "Show me different words", { controller: 'api/v1/responses',
                                                  action: 'sign_in_from_email',
                                                  user_id: @user.id }, class: "neutral-a" %>
             </div>
-            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1; font-size: 1.25rem">
+            <div class="<%= "btn-emotion neutral gap" %>" style="width: 260px; margin: 0 auto; padding: 6px 0 5px 0; line-height: 1;">
               <%= link_to "I'd rather not say...", @link_for_not_say, class: "neutral-a" %>
             </div>
           </div>
         </div>
-        <div class="big-btn-tooltip mx-auto" style="font-size: 1.5rem;">Share it in your own words!</div>
+        <div class="big-btn-tooltip mx-auto">Share it in your own words!</div>
         <div class="big-btn mx-auto">
-          <div class="big-btn-text" style="font-size: 1.875rem;">
+          <div class="big-btn-text">
             <%= link_to "Add your own word", @link_for_own_word %>
           </div>
         </div>
         <div class="links-container">
-          <div class="lnk-unsubscribe" style="text-align: left; font-size: 1rem;">
+          <div class="lnk-unsubscribe" style="text-align: left;">
             <%= link_to "Unsubscribe from future check-ins", { controller: "api/v1/users",
                                                          action: "unsubscribe",
                                                          user_id: @user.id } %>
           </div>
-          <div class="lnk-was-not" style="width: max-content;  font-size: 1.5rem;">
+          <div class="lnk-was-not" style="width: max-content;">
             <%= link_to "I was not working recently", @link_for_was_not %>
           </div>
         </div>

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -206,7 +206,7 @@
                                                             action: "unsubscribe",
                                                             user_id: @user.id } %>
             </td>
-            <td class="lnk-was-not">
+            <td class="lnk-was-not" style="text-align: end;">
               <%= link_to "I was not working recently", @link_for_was_not %>
             </td>
           </tr>

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -187,12 +187,12 @@
         <div class="underline_list"></div>
         <div class='neutral-area' style="padding: 10px 0;">
           <div class="neutral-btns" style="display: flex">
-            <div class="<%= "btn-emotion neutral" %>" style="width: 260px; margin: 0 auto; padding: 8px 0; line-height: 1;">
+            <div class="btn-emotion neutral" style="width: 260px; margin: 0 auto; padding: 8px 0; line-height: 1;">
               <%= link_to "Show me different words", { controller: 'api/v1/responses',
                                                  action: 'sign_in_from_email',
                                                  user_id: @user.id }, class: "neutral-a" %>
             </div>
-            <div class="<%= "btn-emotion neutral gap" %>" style="width: 260px; margin: 0 auto; padding: 8px 0; line-height: 1;">
+            <div class="btn-emotion neutral gap" style="width: 260px; margin: 0 auto; padding: 8px 0; line-height: 1;">
               <%= link_to "I'd rather not say...", @link_for_not_say, class: "neutral-a" %>
             </div>
           </div>

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -27,6 +27,10 @@
           text-align: left;
       }
 
+      .lnk-was-not {
+          text-align: end;
+      }
+
       .emotions-container {
           text-align: center;
       }
@@ -81,14 +85,12 @@
               margin-top: 15px !important;
           }
 
-          .links-container {
-              display: flex;
-              align-items: center !important;
-              justify-content: space-between !important;
-              flex-direction: column !important;
-              margin-top: 40px !important;
-              gap: 10px !important;
-          }
+          .stack-column td {
+              display: block !important;
+              width: 100% !important;
+              text-align: center !important;
+              padding-bottom: 10px !important;
+         }
 
           .lnk-unsubscribe {
               margin-top: 20px !important;
@@ -111,7 +113,7 @@
           }
 
           .big-btn-text a {
-            font-size: 30px !important;
+            font-size: 24px !important;
           }
 
           .big-btn-tooltip {
@@ -201,16 +203,18 @@
             <%= link_to "Add your own word", @link_for_own_word %>
           </div>
         </div>
-        <div class="links-container">
-          <div class="lnk-unsubscribe" style="text-align: left;">
-            <%= link_to "Unsubscribe from future check-ins", { controller: "api/v1/users",
-                                                         action: "unsubscribe",
-                                                         user_id: @user.id } %>
-          </div>
-          <div class="lnk-was-not" style="width: max-content;">
-            <%= link_to "I was not working recently", @link_for_was_not %>
-          </div>
-        </div>
+        <table role="presentation" cellpadding="0" cellspacing="0" width="100%" class="stack-column" style="margin-top: 40px;">
+          <tr>
+            <td class="lnk-unsubscribe">
+              <%= link_to "Unsubscribe from future check-ins", { controller: "api/v1/users",
+                                                            action: "unsubscribe",
+                                                            user_id: @user.id } %>
+            </td>
+            <td class="lnk-was-not">
+              <%= link_to "I was not working recently", @link_for_was_not %>
+            </td>
+          </tr>
+        </table>
       </div>
     </body>
   </html>

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -59,10 +59,6 @@
               padding-top: 5px;
           }
 
-          .ml-55 {
-              margin-left: 0 !important;
-          }
-
           .emotions {
               max-width: 500px !important;
           }
@@ -149,7 +145,7 @@
       <!--[if mso]>
         <table role="presentation" width="100%">
           <tr>
-            <td class="second-row" style="height: 50px; text-align: left; margin-left: 25px; margin-bottom: 10px;">
+            <td class="second-row" style="height: 50px; text-align: left;">
               <table class="calendar" role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 105px; height: 120px; background-image: url('complete-by.png'); background-repeat: no-repeat; background-size: contain;">
                 <tr>
                   <td class="data" style="padding-top: 55px; width: 105px; height: 14px; font-size: 16px; line-height: 17px; color: rgba(0, 0, 0, 0.7); white-space: nowrap; text-transform: capitalize;">
@@ -163,13 +159,13 @@
       <![endif]-->
       <!--[if !mso]><!-->
   <div class="second-row">
-    <div class="calendar" style="margin-left: 25px; margin-bottom: 10px;">
+    <div class="calendar">
       <div class="data"><%= @view_complete_by %></div>
     </div>
   </div>
   <!--<![endif]-->
         <div class="mx-auto invitation">Time for your latest check-in!</div>
-        <div class="mx-auto question">What word best describes how you feel about work?</div>
+        <div class="mx-auto question" style="margin-top: 10px;">What word best describes how you feel about work?</div>
         <div class="emotions-container">
           <% (0..5).each do |row| %>
             <div class="emotions d-flex">

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -35,7 +35,7 @@
           text-align: center;
       }
 
-      @media only screen and (max-width: 767px) {
+      @media only screen and (max-width: 991px) {
           .first-row {
               margin: 0 auto;
               height: auto !important;
@@ -149,7 +149,7 @@
       <!--[if mso]>
         <table role="presentation" width="100%">
           <tr>
-            <td class="second-row" style="height: 50px; text-align: left;">
+            <td class="second-row" style="height: 50px; text-align: left; margin-left: 25px; margin-bottom: 10px;">
               <table class="calendar" role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 105px; height: 120px; background-image: url('complete-by.png'); background-repeat: no-repeat; background-size: contain;">
                 <tr>
                   <td class="data" style="padding-top: 55px; width: 105px; height: 14px; font-size: 16px; line-height: 17px; color: rgba(0, 0, 0, 0.7); white-space: nowrap; text-transform: capitalize;">
@@ -163,13 +163,13 @@
       <![endif]-->
       <!--[if !mso]><!-->
   <div class="second-row">
-    <div class="calendar ml-55">
+    <div class="calendar" style="margin-left: 25px; margin-bottom: 10px;">
       <div class="data"><%= @view_complete_by %></div>
     </div>
   </div>
   <!--<![endif]-->
-        <div class="mx-auto my-0 invitation">Time for your latest check-in!</div>
-        <div class="mx-auto my-0 question">What word best describes how you feel about work?</div>
+        <div class="mx-auto invitation">Time for your latest check-in!</div>
+        <div class="mx-auto question">What word best describes how you feel about work?</div>
         <div class="emotions-container">
           <% (0..5).each do |row| %>
             <div class="emotions d-flex">

--- a/app/views/user_email_mailer/response_invite.html.erb
+++ b/app/views/user_email_mailer/response_invite.html.erb
@@ -136,8 +136,8 @@
     </div>
   </div>
   <!--<![endif]-->
-        <div class="mx-auto my-0 invitation" style="font-size: 1.5rem;">Time for your latest check-in!</div>
-        <div class="mx-auto my-0 question" style="font-size: 2rem;">What word best describes how you feel about work?</div>
+        <div class="mx-auto my-0 invitation" style="font-size: 24px;">Time for your latest check-in!</div>
+        <div class="mx-auto my-0 question">What word best describes how you feel about work?</div>
         <div class="emotions-container">
           <% (0..5).each do |row| %>
             <div class="emotions d-flex">

--- a/app/views/user_email_mailer/results_email.html.erb
+++ b/app/views/user_email_mailer/results_email.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>Email letter</title>
-  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
-  <style>
+  <head>
+    <title>Email letter</title>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
+    <style>
       * {
           margin: 0;
           padding: 0;
@@ -35,42 +35,41 @@
           padding-right: 120px;
           padding-left: 10px;
       }
-  </style>
-  <%= stylesheet_link_tag 'email_page', media: 'all' %>
-</head>
-<body>
-<div class="email-container">
-  <!-- Title & Date -->
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-    <tr>
-      <td width="115" align="center">
-        <div class="calendar-days">
-          <div class="date">
-            <%= @view_calendar_days = "#{@time_period.start_date.strftime('%d %b')}<br>&nbsp;&mdash;&mdash;&nbsp;<br>#{@time_period.end_date.strftime('%d %b')}".html_safe %>
-          </div>
-        </div>
-      </td>
-      <td align="center" class="wrapper">
-        <div class="logo">
-          <%= render 'layouts/logo', height: 61 %>
-        </div>
-        <div>
-          <h1 class="display-4 title-color"><%= @main_header %></h1>
-          <p class="lead title-color"><%= @sub_header || 'See how the team has been doing:' %></p>
-        </div>
-      </td>
-    </tr>
-  </table>
-
-  <!-- BgImage with link -->
-  <div class="container pointer">
-    <%= link_to image_tag("cloud_words.png", class: 'responses-words pointer'),
+    </style>
+    <%= stylesheet_link_tag 'email_page', media: 'all' %>
+  </head>
+  <body>
+    <div class="email-container">
+      <!-- Title & Date -->
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td width="105" height="140" align="center">
+            <div class="calendar-days">
+              <div class="date">
+                <%= @view_calendar_days = "#{@time_period.start_date.strftime('%d %b')}<br>&nbsp;&mdash;&mdash;&nbsp;<br>#{@time_period.end_date.strftime('%d %b')}".html_safe %>
+              </div>
+            </div>
+          </td>
+          <td align="center" class="wrapper">
+            <div class="logo">
+              <%= render 'layouts/logo', height: 61 %>
+            </div>
+            <div>
+              <h1 class="display-4 title-color"><%= @main_header %></h1>
+              <p class="lead title-color"><%= @sub_header || 'See how the team has been doing:' %></p>
+            </div>
+          </td>
+        </tr>
+      </table>
+      <!-- BgImage with link -->
+      <div class="container pointer">
+        <%= link_to image_tag("cloud_words.png", class: 'responses-words pointer'),
                 { controller: "api/v1/results",
                   action: "results_email",
                   slug: @time_period.slug,
                   user_id: @user.id }
     %>
-  </div>
-</div>
-</body>
+      </div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
[![VIB-121](https://badgen.net/badge/JIRA/VIB-121/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-121) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello team, please review PR

## Description
- Fixed font sizes for Outlook client (use media queries in CSS, because clamp() is not supported by Outlook)
- Fixed links layout on the mobile version for a reminder email
- Fixed link alignment for Gmail client