### PR TITLE
VIB-133: Blank page with browser console error appears on Result page after user selects "I'd rather not say" if a Giphy was previously selected

### DIFF
--- a/app/javascript/components/Pages/ListEmotions.js
+++ b/app/javascript/components/Pages/ListEmotions.js
@@ -90,6 +90,7 @@ function ListEmotions({
     steps.push('rather-not-say');
     saveDataToDb(steps, {
       emotion_id: '',
+      gif: {},
       completed_at: null,
       time_period_id: timePeriod.id,
       user_id: data.current_user.id,


### PR DESCRIPTION
[![VIB-133](https://badgen.net/badge/JIRA/VIB-133/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-133) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello team, please review PR

## Description
- Added reassigning empty object to gif if  "I'd rather not say"  is selected