### PR TITLE
VIB-134: User briefly redirected to emotion-selection page before sign-in page when clicking "Ok, log out" on skip-ahead page

### DIFF
--- a/app/javascript/components/Pages/RatherNotSay/SkipAhead.js
+++ b/app/javascript/components/Pages/RatherNotSay/SkipAhead.js
@@ -21,11 +21,14 @@ const RatherNotSay = ({
     </>
 
     const LogoutOrBack = () => {
-        const handleLogout = () => {
-            const id = data?.response?.id;
-            steps.push('emotion-selection-web');
-            saveDataToDb(steps, {draft: false});
-            signOutUser(id).then(() => (window.location.href = `/sign_in`));
+        const handleLogout = async () => {
+            try {
+                const id = data?.response?.id
+                await signOutUser(id);
+                window.location.href = '/users/sign_in';
+            } catch (error) {
+                console.error('Logout failed:', error);
+            }
         };
 
         const handleBack = () => {


### PR DESCRIPTION
[![VIB-134](https://badgen.net/badge/JIRA/VIB-134/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-134) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Description
- Fixed issue causing double redirect when the user signs out