### PR TITLE
VIB-135: The default cursor is shown instead of a pointer when hovering over the Edit button in the shoutout container on the Recognition page

### DIFF
--- a/app/javascript/components/Pages/Recognition.js
+++ b/app/javascript/components/Pages/Recognition.js
@@ -80,7 +80,7 @@ const Recognition = ({data, setData, saveDataToDb, steps, service, draft}) => {
                 <div
                     className="position-absolute top-50 end-0 translate-middle-y d-flex">
                   <img id={shoutOut.id} src={edit_pencil} alt="pencil"
-                       className="pencil" onClick={editHandling}/>
+                       className="pointer" onClick={editHandling}/>
                   <span className="expand-link"
                         onMouseEnter={(e) =>
                             e.currentTarget.querySelector('.trash').


### PR DESCRIPTION
[![VIB-135](https://badgen.net/badge/JIRA/VIB-135/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-135) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review this PR.

1) Applied `pointer ` class to the Edit button in the shoutout container