### PR TITLE
VIB-153: Do not repeat the same person's name in Shoutout updates

### DIFF
--- a/app/workers/emoji_reaction_email_worker.rb
+++ b/app/workers/emoji_reaction_email_worker.rb
@@ -60,6 +60,7 @@ class EmojiReactionEmailWorker
 
   def extract_reactor_names(reactions)
     reactions.filter_map { |r| r.user&.full_name }
+             .uniq
              .to_sentence
   end
 end


### PR DESCRIPTION
[![VIB-153](https://badgen.net/badge/JIRA/VIB-153/009900)](https://cloverpop-internship-2025.atlassian.net/browse/VIB-153) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review PR

## Description
- When the same user gives a different emoji to the same shoutout, it renders multiple times same reactor name, fixed that by applying a unique method to the fetched names