### PR TITLE
VB-28: Fix Response to Innovation Topic text formatting on the Results page (line breaks not preserved)

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -939,3 +939,7 @@ input:checked + .slider-shoutout img {
 .fixed-button-offset {
   padding-bottom: 140px;
 }
+
+.text-pre-wrap {
+  white-space: pre-wrap;
+}

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -204,3 +204,9 @@
 .no-data {
   padding: 0 50px;
 }
+
+.textarea-auto-resize {
+  min-height: 4rem;
+  resize: vertical;
+  height: auto;
+}

--- a/app/javascript/components/Pages/ResultsPage/QuestionSection.js
+++ b/app/javascript/components/Pages/ResultsPage/QuestionSection.js
@@ -179,7 +179,7 @@ const AnswerItem = ({
                           autoFocus={true}
                           onChange={e => setAnswerBody(e.target.value)}
                           value={answerBody}
-                          className='h-auto' />
+                          className='textarea-auto-resize' />
             : <p className="text-pre-wrap text-start">{answer.answer_body}</p>
         }
       </div>

--- a/app/javascript/components/Pages/ResultsPage/QuestionSection.js
+++ b/app/javascript/components/Pages/ResultsPage/QuestionSection.js
@@ -178,8 +178,9 @@ const AnswerItem = ({
                           size="lg"
                           autoFocus={true}
                           onChange={e => setAnswerBody(e.target.value)}
-                          value={answerBody} /> :
-            answer.answer_body
+                          value={answerBody}
+                          className='h-auto' />
+            : <p className="text-pre-wrap text-start">{answer.answer_body}</p>
         }
       </div>
       <EmojiRow {...{

--- a/app/javascript/components/Pages/ResultsPage/TopicSection.js
+++ b/app/javascript/components/Pages/ResultsPage/TopicSection.js
@@ -136,7 +136,7 @@ const BrainstormingItem = ({
                         autoFocus={true}
                         onChange={e => setBrainstormingBody(e.target.value)}
                         value={brainstormingBody}
-                        className='h-auto' />
+                        className='textarea-auto-resize' />
           : <p className="text-pre-wrap text-start">{brainstorming.brainstorming_body}</p>
         }
       </div>

--- a/app/javascript/components/Pages/ResultsPage/TopicSection.js
+++ b/app/javascript/components/Pages/ResultsPage/TopicSection.js
@@ -126,7 +126,7 @@ const BrainstormingItem = ({
           <Link to={''} className='h6 fw-semibold text-success' disabled onClick={updateBrainstorming}>Save</Link>
         </div>}
 
-      <div className='edit-question fs-7 fs-md-6 w-auto text-start fw-semibold lh-base text-pre-wrap'>
+      <div className='edit-question fs-7 fs-md-6 w-auto text-start fw-semibold lh-base'>
         {userFullName(user)} suggested:&nbsp;
         <br />
         {edit ?
@@ -137,7 +137,8 @@ const BrainstormingItem = ({
                         onChange={e => setBrainstormingBody(e.target.value)}
                         value={brainstormingBody}
                         className='h-auto' />
-          : brainstorming.brainstorming_body}
+          : <p className="text-pre-wrap text-start">{brainstorming.brainstorming_body}</p>
+        }
       </div>
 
       <p className={'text-orange-700 text-end'}>Please vote using emoticons</p>

--- a/app/javascript/components/Pages/ResultsPage/TopicSection.js
+++ b/app/javascript/components/Pages/ResultsPage/TopicSection.js
@@ -126,15 +126,17 @@ const BrainstormingItem = ({
           <Link to={''} className='h6 fw-semibold text-success' disabled onClick={updateBrainstorming}>Save</Link>
         </div>}
 
-      <div className='edit-question fs-7 fs-md-6 w-auto text-start fw-semibold lh-base'>
+      <div className='edit-question fs-7 fs-md-6 w-auto text-start fw-semibold lh-base text-pre-wrap'>
         {userFullName(user)} suggested:&nbsp;
         <br />
         {edit ?
           <Form.Control as="textarea" rows={4}
+                        name={"brainstorming-textarea"}
                         size="lg"
                         autoFocus={true}
                         onChange={e => setBrainstormingBody(e.target.value)}
-                        value={brainstormingBody} />
+                        value={brainstormingBody}
+                        className='h-auto' />
           : brainstorming.brainstorming_body}
       </div>
 


### PR DESCRIPTION
## Jira
[![VB-28](https://img.shields.io/badge/VB--28-Task-0052CC?style=flat-square&logo=jira)](https://clearboxdecisions.atlassian.net/browse/VB-28)
This PR implements a fix to preserve line breaks in the text formatting of responses on the Results page. It modifies the rendering logic to ensure that multi-line input from the Innovation-brainstorming page is displayed correctly, maintaining the original structure of the user input.




[VB-28]: https://clearboxdecisions.atlassian.net/browse/VB-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ