### PR TITLE
CP-8815: Require one ai.* label to vibereport repo

### DIFF
--- a/.github/workflows/require-one-ai-label.yml
+++ b/.github/workflows/require-one-ai-label.yml
@@ -1,0 +1,47 @@
+name: Require One AI Label
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+      - edited
+
+jobs:
+  require-ai-label:
+    name: Require one ai label
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate PR labels
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const aiLabels = labels.filter(name => name.startsWith("ai:"));
+
+            core.info(`All labels: ${labels.join(", ") || "(none)"}`);
+            core.info(`Matching ai: labels: ${aiLabels.join(", ") || "(none)"}`);
+
+            if (aiLabels.length === 1) {
+              core.notice(`Exactly one ai: label is present: ${aiLabels[0]}`);
+              return;
+            }
+
+            if (aiLabels.length === 0) {
+              core.setFailed(
+                "This pull request must have exactly one label starting with 'ai:'. Please add before merging."
+              );
+              return;
+            }
+
+            core.setFailed(
+              `This pull request has ${aiLabels.length} labels starting with 'ai:': ${aiLabels.join(", ")}. Please keep exactly one.`
+            );


### PR DESCRIPTION
## Jira
[![CP-8815](https://img.shields.io/badge/CP--8815-Task-0052CC?style=flat-square&logo=jira)](https://clearboxdecisions.atlassian.net/browse/CP-8815)
Implement a validation check in the pull request workflow to ensure that at least one of the AI labels is applied to new PRs in all major repositories. Update the CI/CD pipeline to enforce this requirement and provide a clear error message if the condition is not met.




[CP-8815]: https://clearboxdecisions.atlassian.net/browse/CP-8815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ