### PR TITLE
VB-30: Restrict Modal Closing to Close Button Only

### DIFF
--- a/app/assets/stylesheets/design_system_vibereport.scss
+++ b/app/assets/stylesheets/design_system_vibereport.scss
@@ -38,7 +38,8 @@
   }
 }
 
-input, textarea {
+input,
+textarea {
   height: 4.375rem; //70px
   text-align: left;
   border: 3px solid $royal-blue;
@@ -87,6 +88,14 @@ textarea {
 }
 
 #dropdown-stick {
+
+  &:focus,
+  &:focus-visible,
+  &:active {
+    outline: none;
+    box-shadow: none;
+  }
+
   &.show {
     .one-line-menu {
       border-color: $primary;

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -493,6 +493,17 @@
 }
 
 //ShoutoutModal
+#alert {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  pointer-events: none;
+}
+
+#alert > * {
+  pointer-events: auto;
+}
+
 #overlays {
   position: absolute;
   z-index: 20;
@@ -591,6 +602,7 @@
 
 .placement-modal-message {
   z-index: 22;
+  z-index: 2001;
   max-width: 595px;
   min-height: 282px;
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -601,7 +601,6 @@
 }
 
 .placement-modal-message {
-  z-index: 22;
   z-index: 2001;
   max-width: 595px;
   min-height: 282px;

--- a/app/assets/stylesheets/swal.scss
+++ b/app/assets/stylesheets/swal.scss
@@ -6,6 +6,10 @@ body.swal2-shown > [aria-hidden="true"] {
   filter: blur(50px);
 }
 
+.swal2-container {
+  z-index: 4000 !important;
+}
+
 .swal2-close-button {
   position: absolute;
   top: -13px;

--- a/app/javascript/components/Pages/modals/NotWorkingModal.js
+++ b/app/javascript/components/Pages/modals/NotWorkingModal.js
@@ -16,6 +16,8 @@ const NotWorkingModal = ({ data, makeNotWorking, show, setShow }) => {
       <Modal
         size="lg"
         show={show}
+        backdrop="static"
+        keyboard={true}
         onHide={() => {
           setShow(false);
         }}

--- a/app/javascript/components/Pages/modals/ShoutoutModal.js
+++ b/app/javascript/components/Pages/modals/ShoutoutModal.js
@@ -87,7 +87,7 @@ const ShoutoutModal = ({
         size="lg"
         show={shoutOutForm}
         backdrop="static"
-        keyboard={true}
+        keyboard={isNotAlert}
         onHide={() => {
           setShoutOutForm(false);
         }}

--- a/app/javascript/components/Pages/modals/ShoutoutModal.js
+++ b/app/javascript/components/Pages/modals/ShoutoutModal.js
@@ -56,16 +56,18 @@ const ShoutoutModal = ({
         dataFromServer,
         () => {
         },
-        '/api/v1/shoutouts'
-      ).catch(handlingErrors)
+        '/api/v1/shoutouts',
+        handlingErrors
+      )
       : apiRequest(
         'PATCH',
         dataSend,
         dataFromServer,
         () => {
         },
-        '/api/v1/shoutouts/' + idEditText
-      ).catch(handlingErrors);
+        '/api/v1/shoutouts/' + idEditText,
+        handlingErrors
+      );
   };
 
   const handlingErrors = (errors) => {
@@ -84,6 +86,8 @@ const ShoutoutModal = ({
       <Modal
         size="lg"
         show={shoutOutForm}
+        backdrop="static"
+        keyboard={true}
         onHide={() => {
           setShoutOutForm(false);
         }}

--- a/app/javascript/components/Pages/modals/WorkingModal.js
+++ b/app/javascript/components/Pages/modals/WorkingModal.js
@@ -59,7 +59,7 @@ const WorkingModal = ({show, setShow, data, setData, steps}) => {
         </div>
 
 
-    return <Modal size="lg" show={show} onHide={handleHideModal} animation={true} centered dialogClassName="px-1">
+    return <Modal size="lg" show={show} backdrop="static" keyboard={true} onHide={handleHideModal} animation={true} centered dialogClassName="px-1">
         <button className="position-absolute top-0 start-100 translate-middle x-close bg-transparent border-0"
                 onClick={handleHideModal}>
             <img src={xClose} alt={'Close'}/>

--- a/app/javascript/components/UI/Menu.js
+++ b/app/javascript/components/UI/Menu.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useState} from 'react';
 import {Dropdown} from "react-bootstrap";
 import {signOutUser} from "../requests/axios_requests";
 import Button from "./Button";
@@ -8,7 +8,7 @@ import {SEGMENTS_MAP} from "../helpers/consts";
 const Menu = ({className = '', data, steps, draft, handleSaveDraft, isResult = false}) => {
   const [showModal, setShowModal] = useState(false);
   const [activeImg, setActiveImg] = useState(false);
-  const dropdownRef = useRef(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const alertTitleLogout = "<div class='text-black'>Are you sure you <br/>  want to log out?</div>"
   const id = data?.response?.id
   const lastStep = isResult
@@ -18,27 +18,9 @@ const Menu = ({className = '', data, steps, draft, handleSaveDraft, isResult = f
           : '';
   const isLastStepDisabled = ['emotion-entry', 'emotion-selection-web', 'results', 'rather-not-say', 'skip-ahead'].includes(lastStep);
 
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setActiveImg(false);
-      }
-    };
-    document.addEventListener('click', handleClickOutside);
-  }, []);
-
   const handleSignOut = () => {
     setShowModal(true);
   }
-  const btnElement = document.getElementsByClassName("dropdown")
-
-  const handleChangeImg = () => {
-    if (btnElement[0]?.classList.contains('show')) {
-      setActiveImg(false)
-    } else {
-      setActiveImg(true)
-    }
-  };
 
   const location = window.location.href;
   const lastSegment = isResult ? 'results' : location.substring(location.lastIndexOf("/") + 1);
@@ -62,7 +44,13 @@ const Menu = ({className = '', data, steps, draft, handleSaveDraft, isResult = f
 
   return (
     <div className={`${className}`}>
-      <Dropdown onClick={handleChangeImg} ref={dropdownRef}>
+      <Dropdown
+        show={isDropdownOpen}
+        onToggle={(nextShow) => {
+          setIsDropdownOpen(nextShow);
+          setActiveImg(nextShow);
+        }}
+      >
         <Dropdown.Toggle id='dropdown-stick' className={"rounded-circle bg-white border-0 p-0"}>
           <img src={getSrcMenu(lastSegment, activeImg).src} alt='complete' className={"dropdown-img"} />
         </Dropdown.Toggle>

--- a/app/javascript/components/UI/SweetAlert.js
+++ b/app/javascript/components/UI/SweetAlert.js
@@ -3,7 +3,8 @@ import Swal from "sweetalert2";
 
 const SweetAlert = ({onConfirmAction = () => {}, onDeclineAction = () => {}, alertTitle, alertHtml, cancelButtonText, confirmButtonText,
                       cancelButtonClass, confirmButtonClass, denyButtonText, showCloseButton = true,
-                      showDenyButton = false, showCancelButton = true, showConfirmButton = true}) => {
+                      showDenyButton = false, showCancelButton = true, showConfirmButton = true,
+                      allowOutsideClick = false, allowEscapeKey = true}) => {
   const swalWithBootstrapButtons = Swal.mixin({
     customClass: {
       confirmButton: `btn fs-5 ${confirmButtonClass || 'btn-primary'}`,
@@ -17,6 +18,10 @@ const SweetAlert = ({onConfirmAction = () => {}, onDeclineAction = () => {}, ale
   swalWithBootstrapButtons.fire({
     title: alertTitle,
     html: alertHtml,
+    allowOutsideClick: allowOutsideClick,
+    allowEscapeKey: allowEscapeKey,
+    keydownListenerCapture: true,
+    stopKeydownPropagation: false,
     showCancelButton: showCancelButton,
     showCloseButton: showCloseButton,
     showDenyButton: showDenyButton,

--- a/app/javascript/components/UI/modal/Backdrop.js
+++ b/app/javascript/components/UI/modal/Backdrop.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Backdrop = ({onClose}) => {
-    return <div className='backdrop' onClick={ onClose }/>
+const Backdrop = () => {
+    return <div className='backdrop' />
 };
 
 export default Backdrop;

--- a/app/javascript/components/UI/modal/Portal.js
+++ b/app/javascript/components/UI/modal/Portal.js
@@ -1,14 +1,40 @@
-import React, {Fragment} from 'react';
+import React, {Fragment, useEffect, useRef} from 'react';
 import ReactDOM from "react-dom";
 import Backdrop from "./Backdrop";
 
+const portalStack = [];
+
 const Portal = ({onClose, modalOverlay, elementId = 'overlays' }) => {
+    const portalIdRef = useRef(Symbol('portal-modal'));
 
     const portalElement = document.getElementById(elementId)
 
+    useEffect(() => {
+        portalStack.push(portalIdRef.current);
+
+        const handleKeyDown = (event) => {
+            if (event.key !== 'Escape') return;
+
+            const topPortalId = portalStack[portalStack.length - 1];
+            if (topPortalId !== portalIdRef.current) return;
+
+            onClose();
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            const index = portalStack.indexOf(portalIdRef.current);
+            if (index !== -1) {
+                portalStack.splice(index, 1);
+            }
+        };
+    }, [onClose]);
+
     return (
         <Fragment>
-            {ReactDOM.createPortal(<Backdrop onClose = { onClose }/>, portalElement)}
+            {ReactDOM.createPortal(<Backdrop />, portalElement)}
             {ReactDOM.createPortal( modalOverlay, portalElement)}
         </Fragment>
     );

--- a/app/javascript/components/UI/rich-text/RichInputElement.js
+++ b/app/javascript/components/UI/rich-text/RichInputElement.js
@@ -83,6 +83,9 @@ const RichInputElement = ({
   }, []);
 
   const handleKeyDown = (event) => {
+    if (event.key === 'Escape' && !isDropdownList) {
+      return;
+    }
     event.preventDefault();
     const selectedValue = window.getSelection().toString();
     const text = element.textContent;


### PR DESCRIPTION
## Description 
This PR updates the modal interaction logic to prevent accidental data loss. By disabling "click-to-dismiss" on the backdrop, we ensure that users only close modals through explicit actions, while maintaining keyboard accessibility.

## What changed
- **Backdrop Interaction:** Disabled closing modals by clicking outside the modal area.
- **Consistent Navigation:**  Maintained explicit close paths (e.g., X button, Cancel, OK). Unified Esc key behavior across all dialogs, including SweetAlerts.
- **Stacked Modals:** Pressing Esc now correctly closes only the topmost layer (e.g., an Alert on top of a Modal).
- **Z-Index Fixes:** Improved overlay layering to ensure alert dialogs always appear above other elements.
- **Focus Management:** Fixed an edge case where closing a menu via Esc would leave a "stale" focus ring.

Preserved menu dropdown behavior: it still closes when clicking outside of the dropdown area.

## How to Test 
1. Open any modal in the app.
2. Click outside the modal (on backdrop) → modal should remain open.
3. Click the close button (X/Ok/Close etc) → modal should close.
4. Repeat across different modals in the app to ensure consistency.