### PR TITLE
VB-29: Unify Time Period Date Range Display Across UI, Mailers, and ActiveAdmin

### DIFF
--- a/app/admin/fun_question.rb
+++ b/app/admin/fun_question.rb
@@ -12,6 +12,21 @@ ActiveAdmin.register FunQuestion do
     actions
   end
 
+  show do
+    attributes_table do
+      row :question_body
+      row :user.name
+      row :time_period do |t|
+        link_to t.time_period.date_range,
+                admin_time_period_path(t.time_period) if t.time_period.present?
+      end
+      row :used
+      row :public
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :user, as: :select, collection: User.order(:email).map { |u| ["#{u.email} (#{u.first_name} #{u.last_name})", u.id] }
   filter :time_period, as: :select, collection: TimePeriod.order(start_date: :desc).map { |t| [t.date_range, t.id] }
   filter :public, as: :boolean

--- a/app/admin/fun_question.rb
+++ b/app/admin/fun_question.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register FunQuestion do
     column :question_body
     column :used
     column :public
-    column :user.name
+    column :user
     column :created_at
     actions
   end
@@ -15,7 +15,9 @@ ActiveAdmin.register FunQuestion do
   show do
     attributes_table do
       row :question_body
-      row :user.name
+      row :user do |record|
+        link_to record.user.full_name, admin_user_path(record.user)
+      end
       row :time_period do |t|
         link_to t.time_period.date_range,
                 admin_time_period_path(t.time_period) if t.time_period.present?

--- a/app/admin/innovation_topics.rb
+++ b/app/admin/innovation_topics.rb
@@ -32,6 +32,7 @@ ActiveAdmin.register InnovationTopic do
       end
       row :posted
       row :created_at
+      row :updated_at
     end
 
     panel 'Brainstormings' do

--- a/app/admin/responses.rb
+++ b/app/admin/responses.rb
@@ -22,6 +22,50 @@ ActiveAdmin.register Response do
     actions
   end
 
+  show do
+    attributes_table do
+      row :time_period do |t|
+        link_to t.time_period.date_range,
+                admin_time_period_path(t.time_period) if t.time_period.present?
+      end
+      row :word do |response|
+        response.emotion&.word.presence
+      end
+      row :category do |response|
+        response.emotion&.category.presence
+      end
+      row :user
+      row :not_working
+      row :steps
+      row :rating
+      row :comment
+      row :notices
+      row :productivity
+      row :productivity_comment
+      row :fun_question do |response|
+        if response.fun_question.present?
+          link_to response.fun_question.question_body,
+                  admin_fun_question_path(response.fun_question)
+        end
+      end
+      row :fun_question_answer do |response|
+        if response.fun_question_answer.present?
+          link_to response.fun_question_answer.answer_body,
+                  admin_fun_question_answer_path(response.fun_question_answer)
+        end
+      end
+      row :gif
+      row :draft
+      row :shoutout
+      row :completed_at
+      row :celebrate_comment
+      row :innovation_topic
+      row :innovation_brainstorming
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :user, as: :select, collection: proc { User.joins(:responses).distinct.order(:email).map { |u| ["#{u.email} (#{u.first_name} #{u.last_name})", u.id] } }
   filter :time_period, as: :select, collection: TimePeriod.order(start_date: :desc).map { |t| [t.date_range, t.id] }
   filter :emotion, as: :select, collection: proc { Emotion.pluck(:word, :id) }, label: 'Word'

--- a/app/admin/responses.rb
+++ b/app/admin/responses.rb
@@ -28,11 +28,8 @@ ActiveAdmin.register Response do
         link_to t.time_period.date_range,
                 admin_time_period_path(t.time_period) if t.time_period.present?
       end
-      row :word do |response|
-        response.emotion&.word.presence
-      end
-      row :category do |response|
-        response.emotion&.category.presence
+      row :emotion do |response|
+        link_to response.emotion.word, admin_emotion_path(response.emotion) if response.emotion.present?
       end
       row :user
       row :not_working

--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -98,7 +98,7 @@ ActiveAdmin.register Team do
           time_periods = TimePeriod.with_responses_by_team(team)
                                    .select("DISTINCT DATE_TRUNC('month', start_date) as month_start")
                                    .order(month_start: :desc)
-                                   .map { |tp| [tp.month_start.strftime('%Y-%m'), tp.month_start.strftime('%Y-%m-%d')] }
+                                   .map { |tp| [tp.month_start.strftime(DateFormats::MONTH_YEAR_FULL), tp.month_start.strftime(DateFormats::STANDARD_DATE)] }
           select_tag :time_period,
                      options_for_select(time_periods, params[:time_period]),
                      include_blank: 'Select Month',
@@ -141,7 +141,7 @@ ActiveAdmin.register Team do
       )
 
       if time_periods.present?
-        panel "Month: <span style='color: #007BFF; font-weight: bold;'>#{selected_month.strftime('%B %Y')}</span>".html_safe do
+        panel "Month: <span style='color: #007BFF; font-weight: bold;'>#{selected_month.strftime(DateFormats::MONTH_YEAR_FULL)}</span>".html_safe do
           responses_count = Response.joins(user: :teams)
                                     .where(teams: { id: team.id }, time_period: time_periods, not_working: false)
                                     .count
@@ -284,7 +284,7 @@ ActiveAdmin.register Team do
       if earliest_start_date.nil? || latest_end_date.nil?
         panel "All Time: <span style='color: #007bff; font-weight: bold;'>No data present for this period</span>".html_safe
       else
-        panel "All Time: <span style='color: #007bff; font-weight: bold;'>#{earliest_start_date.strftime('%B %Y')}</span> - <span style='color: #007bff; font-weight: bold;'>#{latest_end_date.strftime('%B %Y')}</span>".html_safe do
+        panel "All Time: <span style='color: #007bff; font-weight: bold;'>#{earliest_start_date.strftime(DateFormats::MONTH_YEAR_FULL)}</span> - <span style='color: #007bff; font-weight: bold;'>#{latest_end_date.strftime(DateFormats::MONTH_YEAR_FULL)}</span>".html_safe do
           responses_count = Response.joins(user: :teams)
                                     .where(user: { teams: team })
                                     .working

--- a/app/admin/time_periods.rb
+++ b/app/admin/time_periods.rb
@@ -4,10 +4,11 @@ ActiveAdmin.register TimePeriod do
   index do
     selectable_column
     id_column
+    column('Week of', sortable: :start_date) { |time_period| time_period.date_range }
     column :start_date
     column :end_date
-    column :created_at
     column :due_date
+    column :created_at
     column :slug
     actions
   end
@@ -26,11 +27,7 @@ ActiveAdmin.register TimePeriod do
     f.actions
   end
 
-  show title: lambda { |time_period|
-    "#{time_period.first_working_day.strftime('%b %e')}
-    - #{time_period.last_working_day.strftime('%b %e')},
-    #{time_period.last_working_day.strftime('%Y')}"
-  } do
+  show title: :date_range do
     columns do
       column do
         panel 'Participation by Team' do

--- a/app/admin/time_sheet_entries.rb
+++ b/app/admin/time_sheet_entries.rb
@@ -13,7 +13,7 @@ ActiveAdmin.register TimeSheetEntry do
     selectable_column
     id_column
     column('Week of', :time_period, sortable: 'time_periods.start_date') do |time_sheet_entry|
-      time_sheet_entry.time_period.date_range_str
+      time_sheet_entry.time_period.date_range
     end
     column('Project code', :project, sortable: 'projects.code') { |time_sheet_entry| time_sheet_entry.project.code }
     column 'Logged Hours', :total_hours
@@ -23,7 +23,7 @@ ActiveAdmin.register TimeSheetEntry do
 
   filter :time_period, as: :select, label: 'Week of', collection: TimePeriod.select(:id, :start_date, :end_date)
                                                                             .ordered
-                                                                            .map { |tp| [tp.date_range_str, tp.id] }
+                                                                            .map { |tp| [tp.date_range, tp.id] }
   filter :project, as: :select, label: 'Project code', collection: Project.pluck(:code, :id)
   filter :user, as: :select, label: 'Person', collection: User.opt_in.select(:id, :first_name, :last_name).map { |user|
     [user.full_name, user.id]
@@ -35,8 +35,8 @@ ActiveAdmin.register TimeSheetEntry do
         [user.full_name, user.id]
       }, include_blank: false
       f.input :project, as: :select, collection: Project.pluck(:code, :id), include_blank: false
-      f.input :time_period, as: :select, collection: TimePeriod.select(:id, :start_date, :end_date).map { |time_period|
-        [time_period.date_range_str, time_period.id]
+      f.input :time_period, as: :select, collection: TimePeriod.select(:id, :start_date, :end_date).ordered.map { |time_period|
+        [time_period.date_range, time_period.id]
       }, include_blank: false
       f.input :total_hours
     end
@@ -45,7 +45,7 @@ ActiveAdmin.register TimeSheetEntry do
 
   show do
     attributes_table do
-      row('Week of') { |time_sheet_entry| time_sheet_entry.time_period.date_range_str }
+      row('Week of') { |time_sheet_entry| time_sheet_entry.time_period.date_range }
       row('Project code') { |time_sheet_entry| time_sheet_entry.project.code }
       row('Logged Hours') { |time_sheet_entry| time_sheet_entry.total_hours }
       row('Person') { |time_period| time_period.user.full_name }
@@ -65,7 +65,7 @@ ActiveAdmin.register TimeSheetEntry do
       time_periods = @time_sheet_entries.map(&:time_period).uniq
 
       formatted_period = if time_periods.one?
-                           "#{time_periods.first.date_range_str} #{time_periods.first.start_date.year}"
+                           "#{time_periods.first.date_range} #{time_periods.first.start_date.year}"
                          else
                            Time.zone.today.strftime('%d-%m-%Y')
                          end

--- a/app/admin/time_sheet_entries.rb
+++ b/app/admin/time_sheet_entries.rb
@@ -65,9 +65,9 @@ ActiveAdmin.register TimeSheetEntry do
       time_periods = @time_sheet_entries.map(&:time_period).uniq
 
       formatted_period = if time_periods.one?
-                           "#{time_periods.first.date_range} #{time_periods.first.start_date.year}"
+                           time_periods.first.date_range_for_csv.to_s
                          else
-                           Time.zone.today.strftime('%d-%m-%Y')
+                           Time.zone.today.strftime(DateFormats::STANDARD_DATE)
                          end
 
       "Timesheet Entries #{formatted_period}.csv"

--- a/app/helpers/user_email_mailer_helper.rb
+++ b/app/helpers/user_email_mailer_helper.rb
@@ -46,10 +46,10 @@ module UserEmailMailerHelper
   def text_for_waiting(is_manager, teams_with_managers, managers, time_period)
     if is_manager && teams_with_managers.any?
       "The #{teams_with_managers.pluck(:name).to_sentence} #{'team'.pluralize(teams_with_managers.count)} " \
-        "#{teams_with_managers.count == 1 ? 'is' : 'are'} waiting for you to check-in for #{time_period.date_range_str}"
+        "#{teams_with_managers.count == 1 ? 'is' : 'are'} waiting for you to check-in for #{time_period.date_range}"
     elsif managers.any?
       "#{managers.pluck(:first_name).to_sentence} #{managers.count == 1 ? 'is' : 'are'} " \
-        "waiting for you to check-in for #{time_period.date_range_str}"
+        "waiting for you to check-in for #{time_period.date_range}"
     end
   end
 end

--- a/app/javascript/components/Pages/ListEmotions.js
+++ b/app/javascript/components/Pages/ListEmotions.js
@@ -81,7 +81,7 @@ function ListEmotions({
   const rangeFormat = (tp) => {
     const dueDate = new Date(tp.due_date);
     const month = dueDate
-      .toLocaleString('default', {month: 'long'})
+      .toLocaleString('en-US', {month: 'long'})
       .slice(0, 3);
     return month + ' ' + `${dueDate.getDate()}`.padStart(2, '0');
   };

--- a/app/mailers/time_sheet_mailer.rb
+++ b/app/mailers/time_sheet_mailer.rb
@@ -1,6 +1,5 @@
 class TimeSheetMailer < ApplicationMailer
   EXCEL_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'.freeze
-  TIMESHEET_DISPLAY_DATE_FORMAT = '%d %b %Y'.freeze
 
   def time_sheet_results_email(entries, grouped_entries, time_period, attach_excel: true, last_months_period: 12)
     @grouped_entries = grouped_entries
@@ -15,14 +14,14 @@ class TimeSheetMailer < ApplicationMailer
 
     mail(
       to: recipients,
-      subject: "Timesheet Entries #{Time.zone.today.strftime(TIMESHEET_DISPLAY_DATE_FORMAT)}"
+      subject: "Timesheet Entries #{Time.zone.today.strftime(DateFormats::DAY_MONTH_YEAR)}"
     )
   end
 
   private
 
   def attach_timesheets_excel_file(entries)
-    file_name = "Timesheet Entries #{Time.zone.today.strftime(TIMESHEET_DISPLAY_DATE_FORMAT)}.xlsx"
+    file_name = "Timesheet Entries #{Time.zone.today.strftime(DateFormats::DAY_MONTH_YEAR)}.xlsx"
     excel_data = Exporters::TimeSheetExcelExporter.new(entries).call
 
     attachments[file_name] = {

--- a/app/mailers/user_email_mailer.rb
+++ b/app/mailers/user_email_mailer.rb
@@ -17,7 +17,7 @@ class UserEmailMailer < ApplicationMailer
     end
     @url_sign_in_from_email = SignedLinks::SignInFromEmailBuilder.url(user)
     @url_unsubscribe = SignedLinks::UnsubscribeBuilder.url(user)
-    @view_complete_by = time_period.due_date.strftime('%b %d').to_s
+    @view_complete_by = time_period.due_date.strftime(DateFormats::MONTH_DAY).to_s
     mail(to: user.email, subject: "Hey #{user.first_name}, how has work been?")
   end
 

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -83,6 +83,10 @@ class TimePeriod < ApplicationRecord
     work_week_range
   end
 
+  def date_range_for_csv
+    "#{first_working_day.strftime(DateFormats::MONTH_DAY)} - #{last_working_day.strftime(DateFormats::MONTH_DAY_YEAR)}"
+  end
+
   def self.overdue_after_forced_date
     forced_entry_date = ENV.fetch('TIMESHEET_START_FORCED_ENTRY_DATE', nil)
     return none if forced_entry_date.blank?

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -79,8 +79,9 @@ class TimePeriod < ApplicationRecord
     start_date.end_of_week(:saturday)
   end
 
-  def date_range
-    work_week_range
+  def date_range(start_format = DateFormats::MONTH_DAY,
+                 end_format = DateFormats::MONTH_DAY_YEAR_COMMA)
+    "#{first_working_day.strftime(start_format)} - #{last_working_day.strftime(end_format)}"
   end
 
   def date_range_for_csv
@@ -101,12 +102,5 @@ class TimePeriod < ApplicationRecord
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[due_date end_date slug start_date]
-  end
-
-  private
-
-  def work_week_range(start_format = DateFormats::MONTH_DAY,
-                      end_format = DateFormats::MONTH_DAY_YEAR_COMMA)
-    "#{first_working_day.strftime(start_format)} - #{last_working_day.strftime(end_format)}"
   end
 end

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -58,7 +58,7 @@ class TimePeriod < ApplicationRecord
 
       start_date = Date.current.beginning_of_week(day_that_week_starts)
       end_date = start_date + 6.days
-      due_date = (start_date..end_date).find { |date| date.strftime('%A').downcase.to_sym == day_to_send_invites }
+      due_date = (start_date..end_date).find { |date| date.strftime(DateFormats::DAY_NAME_FULL).downcase.to_sym == day_to_send_invites }
       TimePeriod.create!(start_date:, end_date:, due_date:)
     end
 
@@ -80,18 +80,14 @@ class TimePeriod < ApplicationRecord
   end
 
   def date_range
-    work_week_range('%Y-%m-%d')
-  end
-
-  def date_range_str
-    work_week_range('%b %d')
+    work_week_range
   end
 
   def self.overdue_after_forced_date
     forced_entry_date = ENV.fetch('TIMESHEET_START_FORCED_ENTRY_DATE', nil)
     return none if forced_entry_date.blank?
 
-    start_date = Date.strptime(forced_entry_date, DATE_FORMAT)
+    start_date = Date.strptime(forced_entry_date, DateFormats::STANDARD_DATE)
     where(end_date: start_date...Date.current)
   end
 
@@ -105,7 +101,8 @@ class TimePeriod < ApplicationRecord
 
   private
 
-  def work_week_range(format_string)
-    "#{start_date.beginning_of_week.strftime(format_string)} - #{start_date.end_of_week.strftime(format_string)}"
+  def work_week_range(start_format = DateFormats::MONTH_DAY,
+                      end_format = DateFormats::MONTH_DAY_YEAR_COMMA)
+    "#{first_working_day.strftime(start_format)} - #{last_working_day.strftime(end_format)}"
   end
 end

--- a/app/reports/responses_report.rb
+++ b/app/reports/responses_report.rb
@@ -31,6 +31,7 @@ class ResponsesReport < AdminReport
   def response_data(response_counts)
     time_periods = TimePeriod.select(:id, :start_date, :end_date)
                              .where(id: response_counts.keys)
+                             .order(:start_date)
 
     response_counts.map do |time_period_id, count|
       time_period = time_periods.find { |tp| tp.id == time_period_id }
@@ -42,6 +43,7 @@ class ResponsesReport < AdminReport
   def create_chart(data, chart_id)
     area_chart data,
                xtitle: 'Period', ytitle: 'Count', id: chart_id,
-               library: { colors: ['green'], title: { fontName: 'Arial', fontSize: 18 } }
+               library: { colors: ['green'], title: { fontName: 'Arial', fontSize: 18 } },
+               discrete: true # make X-axis categorical instead of date-based
   end
 end

--- a/app/services/exporters/time_sheet_excel_exporter.rb
+++ b/app/services/exporters/time_sheet_excel_exporter.rb
@@ -17,7 +17,7 @@ class Exporters::TimeSheetExcelExporter
       .sort_by { |tp, _| tp.start_date }
       .reverse_each do |time_period, entries|
 
-      sheet_name = time_period.date_range_str.first(MAX_SHEET_NAME_LENGTH)
+      sheet_name = time_period.date_range.first(MAX_SHEET_NAME_LENGTH)
 
       workbook.add_worksheet(name: sheet_name) do |sheet|
         # header row

--- a/app/views/emoji_reactions_mailer/emoji_reaction_email.html.erb
+++ b/app/views/emoji_reactions_mailer/emoji_reaction_email.html.erb
@@ -11,10 +11,6 @@
           width: 100% !important;
           max-width: 100% !important;
         }
-
-        .center-text {
-          text-align: center !important;
-        }
       }
     </style>
   </head>
@@ -23,7 +19,7 @@
       <tr>
         <td class="stack-column" style="vertical-align: top; width: 130px; text-align: center; background: url('<%= image_url("calendar_days.png") %>') no-repeat center top; background-size: contain; height: 105px;">
           <div style="padding-top: 48px; padding-bottom: 4px; font-size: 16px; line-height: 1.2; color: rgba(0, 0, 0, 0.7); text-transform: capitalize; font-weight: bold;">
-            <%= @view_calendar_days = "#{@time_period.start_date.strftime('%d %b')}<br>&mdash;&mdash;<br>#{@time_period.end_date.strftime('%d %b')}".html_safe %>
+            <%= @view_calendar_days = "#{@time_period.start_date.strftime(DateFormats::MONTH_DAY)}<br>&mdash;&mdash;<br>#{@time_period.end_date.strftime(DateFormats::MONTH_DAY)}".html_safe %>
           </div>
         </td>
         <td class="stack-column" style="text-align: left; vertical-align: middle;">

--- a/app/views/time_sheet_mailer/time_sheet_results_email.html.erb
+++ b/app/views/time_sheet_mailer/time_sheet_results_email.html.erb
@@ -7,7 +7,7 @@
             <td style="padding: 20px 0; text-align: center;">
               <%= content_tag(:h2,
                               @has_entries_in_report_range ?
-                                "Timesheet Entries for #{@time_period.date_range_str}" :
+                                "Timesheet Entries for #{@time_period.date_range}" :
                                 "No timesheet entries were found for the past #{pluralize(@time_sheet_last_months_period, "month")}.",
                               style: "margin: 0;")
               %>

--- a/app/views/user_email_mailer/daily_timesheet_reminder.html.erb
+++ b/app/views/user_email_mailer/daily_timesheet_reminder.html.erb
@@ -106,7 +106,7 @@
           <li>
             <strong>
               <%= link[:period].first_working_day.strftime(DateFormats::MONTH_DAY) %> -
-              <%= link[:period].last_working_day.strftime(DateFormats::MONTH_DAY_YEAR) %>
+              <%= link[:period].last_working_day.strftime(DateFormats::MONTH_DAY_YEAR_COMMA) %>
             </strong>
             -
             <%= link_to 'Fill timesheet', link[:url], target: '_blank' %>

--- a/app/views/user_email_mailer/daily_timesheet_reminder.html.erb
+++ b/app/views/user_email_mailer/daily_timesheet_reminder.html.erb
@@ -105,8 +105,8 @@
         <% @links.each do |link| %>
           <li>
             <strong>
-              <%= link[:period].first_working_day.strftime('%b %d') %> -
-              <%= link[:period].last_working_day.strftime('%b %d, %Y') %>
+              <%= link[:period].first_working_day.strftime(DateFormats::MONTH_DAY) %> -
+              <%= link[:period].last_working_day.strftime(DateFormats::MONTH_DAY_YEAR) %>
             </strong>
             -
             <%= link_to 'Fill timesheet', link[:url], target: '_blank' %>

--- a/app/views/user_email_mailer/reminder_email.html.erb
+++ b/app/views/user_email_mailer/reminder_email.html.erb
@@ -45,7 +45,7 @@
               <table class="calendar" role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 102px; height: 115px; background-image: url('complete-by.png'); background-repeat: no-repeat; background-size: contain;">
                 <tr>
                   <td class="data" style="padding-top: 55px; width: 102px; height: 14px; font-size: 16px; line-height: 17px; color: rgba(0, 0, 0, 0.7); white-space: nowrap; text-transform: capitalize;">
-                    <%= @view_calendar_days = "#{@time_period.end_date.strftime('%d %b')}".html_safe %>
+                    <%= @view_calendar_days = "#{@time_period.end_date.strftime(DateFormats::MONTH_DAY)}".html_safe %>
                   </td>
                 </tr>
               </table>
@@ -56,7 +56,7 @@
       <!--[if !mso]><!-->
   <div class="first-row-reminder">
     <div class="calendar">
-      <div class="data"><%= @view_calendar_days = "#{@time_period.end_date.strftime('%d %b')}".html_safe %></div>
+      <div class="data"><%= @view_calendar_days = "#{@time_period.end_date.strftime(DateFormats::MONTH_DAY)}".html_safe %></div>
     </div>
   </div>
   <!--<![endif]-->

--- a/app/views/user_email_mailer/results_email.html.erb
+++ b/app/views/user_email_mailer/results_email.html.erb
@@ -46,7 +46,7 @@
           <td width="105" height="140" align="center">
             <div class="calendar-days">
               <div class="date">
-                <%= @view_calendar_days = "#{@time_period.start_date.strftime('%d %b')}<br>&nbsp;&mdash;&mdash;&nbsp;<br>#{@time_period.end_date.strftime('%d %b')}".html_safe %>
+                <%= @view_calendar_days = "#{@time_period.start_date.strftime(DateFormats::MONTH_DAY)}<br>&nbsp;&mdash;&mdash;&nbsp;<br>#{@time_period.end_date.strftime(DateFormats::MONTH_DAY)}".html_safe %>
               </div>
             </div>
           </td>

--- a/app/workers/daily_overdue_timesheet_worker.rb
+++ b/app/workers/daily_overdue_timesheet_worker.rb
@@ -25,11 +25,11 @@ class DailyOverdueTimesheetWorker
     raw = ENV.fetch(FORCE_DATE_ENV, nil)
     return false if raw.blank?
 
-    force_date = Date.strptime(raw, DATE_FORMAT)
+    force_date = Date.strptime(raw, DateFormats::STANDARD_DATE)
     Date.current >= force_date
   rescue ArgumentError
     Rails.logger.error(
-      "[DailyOverdueTimesheetWorker] Invalid #{FORCE_DATE_ENV}=#{raw.inspect}. Expected format #{DATE_FORMAT}."
+      "[DailyOverdueTimesheetWorker] Invalid #{FORCE_DATE_ENV}=#{raw.inspect}. Expected format #{DateFormats::STANDARD_DATE}."
     )
     false
   end

--- a/app/workers/emotion_selection_notification_worker.rb
+++ b/app/workers/emotion_selection_notification_worker.rb
@@ -7,7 +7,7 @@ class EmotionSelectionNotificationWorker
   end
 
   def run_notification
-    return unless Date.current.strftime('%A').casecmp?(ENV.fetch('DAY_TO_SEND_INVITES'))
+    return unless Date.current.strftime(DateFormats::DAY_NAME_FULL).casecmp?(ENV.fetch('DAY_TO_SEND_INVITES'))
 
     run_notification!
   end

--- a/app/workers/remind_check_in_email_worker.rb
+++ b/app/workers/remind_check_in_email_worker.rb
@@ -7,7 +7,7 @@ class RemindCheckInEmailWorker
   end
 
   def run_notification
-    return unless Date.current.strftime('%A').casecmp?(ENV['DAY_TO_SEND_FINAL_REMINDER'] || '')
+    return unless Date.current.strftime(DateFormats::DAY_NAME_FULL).casecmp?(ENV['DAY_TO_SEND_FINAL_REMINDER'] || '')
 
     send_reminder_emails!
   end

--- a/app/workers/results_notification_worker.rb
+++ b/app/workers/results_notification_worker.rb
@@ -8,7 +8,7 @@ class ResultsNotificationWorker
   end
 
   def run_notification
-    return unless Date.current.strftime('%A').casecmp?(ENV.fetch('DAY_TO_SEND_RESULTS_EMAIL'))
+    return unless Date.current.strftime(DateFormats::DAY_NAME_FULL).casecmp?(ENV.fetch('DAY_TO_SEND_RESULTS_EMAIL'))
 
     run_results_email!
   end

--- a/app/workers/time_sheet_results_email_worker.rb
+++ b/app/workers/time_sheet_results_email_worker.rb
@@ -6,7 +6,7 @@ class TimeSheetResultsEmailWorker
   end
 
   def run_notification
-    return unless Date.current.strftime('%A')
+    return unless Date.current.strftime(DateFormats::DAY_NAME_FULL)
                       .casecmp?(ENV.fetch('DAY_TO_SEND_RESULTS_EMAIL', nil))
 
     excel_entries = fetch_entries

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,13 @@
-DATE_FORMAT = '%Y-%m-%d'.freeze
+module DateFormats
+  MONTH_YEAR = '%b %Y'.freeze                # Mar 2026
+  MONTH_YEAR_FULL = '%B %Y'.freeze           # March 2026
+  MONTH_DAY = '%b %d'.freeze                 # Mar 31
+  MONTH_DAY_YEAR = '%b %d %Y'.freeze         # Mar 31 2026
+  MONTH_DAY_YEAR_COMMA = '%b %d, %Y'.freeze  # Mar 31, 2026
+
+  DAY_MONTH_YEAR = '%d %b %Y'.freeze         # 31 Mar 2026
+
+  STANDARD_DATE = '%Y-%m-%d'.freeze          # ISO standard date format YYYY-MM-DD (for parsing)
+
+  DAY_NAME_FULL = '%A'.freeze                # Wednesday
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,3 +63,5 @@ en:
       innovation_brainstorming:
         brainstorming_body: "Brainstorming"
         innovation_topic: "Topic"
+      fun_question:
+        question_body: "Question"

--- a/spec/helpers/user_email_mailer_helper_spec.rb
+++ b/spec/helpers/user_email_mailer_helper_spec.rb
@@ -54,7 +54,7 @@ describe UserEmailMailerHelper, type: :helper do
       team = user_team.team
       user_team2.team
       result = who_is_waiting(user, time_period)
-      expect(result).to eq("The #{team.name} team is waiting for you to check-in for #{time_period.date_range_str}")
+      expect(result).to eq("The #{team.name} team is waiting for you to check-in for #{time_period.date_range}")
     end
 
     it 'returns nil when the user is not a manager' do

--- a/spec/mailers/time_sheet_mailer_spec.rb
+++ b/spec/mailers/time_sheet_mailer_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe TimeSheetMailer, type: :mailer do
   end
 
   it 'has the correct subject' do
-    expect(mail.subject).to eq("Timesheet Entries #{Time.zone.today.strftime(TimeSheetMailer::TIMESHEET_DISPLAY_DATE_FORMAT)}")
+    expect(mail.subject).to eq("Timesheet Entries #{Time.zone.today.strftime(DateFormats::DAY_MONTH_YEAR)}")
   end
 
   it 'contains the correct date range' do
-    expect(mail.body.encoded).to include(time_period.date_range_str)
+    expect(mail.body.encoded).to include(time_period.date_range)
   end
 
   it 'contains the correct project code and total hours' do
@@ -46,7 +46,7 @@ RSpec.describe TimeSheetMailer, type: :mailer do
   it 'attaches an Excel file' do
     expect(mail.attachments.count).to eq(1)
     file = mail.attachments.first
-    expect(file.filename).to eq("Timesheet Entries #{Time.zone.today.strftime(TimeSheetMailer::TIMESHEET_DISPLAY_DATE_FORMAT)}.xlsx")
+    expect(file.filename).to eq("Timesheet Entries #{Time.zone.today.strftime(DateFormats::DAY_MONTH_YEAR)}.xlsx")
     expect(file.content_type).to eq(TimeSheetMailer::EXCEL_MIME_TYPE)
   end
 end

--- a/spec/models/time_period_spec.rb
+++ b/spec/models/time_period_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe TimePeriod, type: :model do
 
     context '#date_range' do
       it 'returns the correct date range string' do
-        start_date = time_period1.start_date.beginning_of_week.strftime('%Y-%m-%d')
-        end_date = time_period1.start_date.end_of_week.strftime('%Y-%m-%d')
+        start_date = time_period1.first_working_day.strftime(DateFormats::MONTH_DAY)
+        end_date = time_period1.last_working_day.strftime(DateFormats::MONTH_DAY_YEAR_COMMA)
 
         expect(time_period1.date_range).to eq("#{start_date} - #{end_date}")
       end
@@ -163,7 +163,7 @@ RSpec.describe TimePeriod, type: :model do
     context 'when TIMESHEET_START_FORCED_ENTRY_DATE is in the past' do
       before do
         stub_const('ENV', ENV.to_hash.merge(
-                            'TIMESHEET_START_FORCED_ENTRY_DATE' => (REFERENCE_DATE - 21.days).strftime('%Y-%m-%d')
+                            'TIMESHEET_START_FORCED_ENTRY_DATE' => (REFERENCE_DATE - 21.days).strftime(DateFormats::STANDARD_DATE)
         ))
       end
 
@@ -176,7 +176,7 @@ RSpec.describe TimePeriod, type: :model do
     context 'when TIMESHEET_START_FORCED_ENTRY_DATE is today' do
       before do
         stub_const('ENV', ENV.to_hash.merge(
-                            'TIMESHEET_START_FORCED_ENTRY_DATE' => REFERENCE_DATE.strftime('%Y-%m-%d')
+                            'TIMESHEET_START_FORCED_ENTRY_DATE' => REFERENCE_DATE.strftime(DateFormats::STANDARD_DATE)
         ))
       end
 
@@ -188,7 +188,7 @@ RSpec.describe TimePeriod, type: :model do
     context 'when TIMESHEET_START_FORCED_ENTRY_DATE is in the future' do
       before do
         stub_const('ENV', ENV.to_hash.merge(
-                            'TIMESHEET_START_FORCED_ENTRY_DATE' => (REFERENCE_DATE + 5.days).strftime('%Y-%m-%d')
+                            'TIMESHEET_START_FORCED_ENTRY_DATE' => (REFERENCE_DATE + 5.days).strftime(DateFormats::STANDARD_DATE)
         ))
       end
 

--- a/spec/requests/time_sheet_entries_spec.rb
+++ b/spec/requests/time_sheet_entries_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'TimeSheetEntries API', type: :request do
   before { sign_in(user) }
   before do
     stub_const('ENV', ENV.to_hash.merge(
-                        'TIMESHEET_START_FORCED_ENTRY_DATE' => 20.days.ago.strftime(DATE_FORMAT)
+                        'TIMESHEET_START_FORCED_ENTRY_DATE' => 20.days.ago.strftime(DateFormats::STANDARD_DATE)
                       ))
   end
 

--- a/spec/services/exporters/time_sheet_excel_exporter_spec.rb
+++ b/spec/services/exporters/time_sheet_excel_exporter_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Exporters::TimeSheetExcelExporter do
     it 'creates sheets only for past periods with correct names' do
       workbook_double = instance_double(Axlsx::Workbook)
       allow(Axlsx::Package).to receive(:new).and_return(double(workbook: workbook_double, to_stream: double(read: 'binary_data')))
-      expect(workbook_double).to receive(:add_worksheet).with(hash_including(name: past_period.date_range_str.first(31)))
-      expect(workbook_double).not_to receive(:add_worksheet).with(hash_including(name: future_period.date_range_str.first(31)))
+      expect(workbook_double).to receive(:add_worksheet).with(hash_including(name: past_period.date_range.first(31)))
+      expect(workbook_double).not_to receive(:add_worksheet).with(hash_including(name: future_period.date_range.first(31)))
 
       exporter.call
     end
@@ -55,7 +55,7 @@ RSpec.describe Exporters::TimeSheetExcelExporter do
 
     it 'limits sheet name to MAX_SHEET_NAME_LENGTH characters' do
       long_period = create(:time_period, start_date: 2.weeks.ago, end_date: 1.week.ago)
-      allow(long_period).to receive(:date_range_str).and_return('X' * 50)
+      allow(long_period).to receive(:date_range).and_return('X' * 50)
 
       entry_with_long_period = create(
         :time_sheet_entry,

--- a/spec/workers/daily_overdue_timesheet_worker_spec.rb
+++ b/spec/workers/daily_overdue_timesheet_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DailyOverdueTimesheetWorker do
            due_date: REFERENCE_DATE - 14.days)
   end
 
-  let(:force_date) { (REFERENCE_DATE - 30.days).strftime(DATE_FORMAT) }
+  let(:force_date) { (REFERENCE_DATE - 30.days).strftime(DateFormats::STANDARD_DATE) }
 
   before do
     stub_const('ENV', ENV.to_hash.merge(
@@ -61,7 +61,7 @@ RSpec.describe DailyOverdueTimesheetWorker do
     end
 
     context 'when force date has not been reached yet' do
-      let(:force_date) { (REFERENCE_DATE + 5.days).strftime(DATE_FORMAT) }
+      let(:force_date) { (REFERENCE_DATE + 5.days).strftime(DateFormats::STANDARD_DATE) }
 
       it 'does not send any emails' do
         expect { worker.run }

--- a/spec/workers/emotion_selection_notification_worker_spec.rb
+++ b/spec/workers/emotion_selection_notification_worker_spec.rb
@@ -28,14 +28,14 @@ describe EmotionSelectionNotificationWorker do
 
   describe '.run_notifications' do
     it 'sends email notifications' do
-      stub_const('ENV', ENV.to_hash.merge('DAY_TO_SEND_INVITES' => Date.current.strftime('%A')))
+      stub_const('ENV', ENV.to_hash.merge('DAY_TO_SEND_INVITES' => Date.current.strftime(DateFormats::DAY_NAME_FULL)))
       run_worker
       mail_recipients = ActionMailer::Base.deliveries.collect { |mail| mail.to[0] }
       expect(mail_recipients.count).to eql 2
       expect(mail_recipients).to match_array([user1.email, user2.email])
     end
     it 'does`t sends email notifications unless the ENV variable is set on the current day' do
-      stub_const('ENV', ENV.to_hash.merge('DAY_TO_SEND_INVITES' => (Date.current + 2).strftime('%A')))
+      stub_const('ENV', ENV.to_hash.merge('DAY_TO_SEND_INVITES' => (Date.current + 2).strftime(DateFormats::DAY_NAME_FULL)))
       run_worker
       mail_recipients = ActionMailer::Base.deliveries.collect { |mail| mail.to[0] }
       expect(mail_recipients.count).to eql 0

--- a/spec/workers/remind_check_in_email_worker_spec.rb
+++ b/spec/workers/remind_check_in_email_worker_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RemindCheckInEmailWorker do
 
   before(:each) do
     Faker::UniqueGenerator.clear
-    stub_const('ENV', ENV.to_hash.merge('DAY_TO_SEND_FINAL_REMINDER' => Date.current.strftime('%A')))
+    stub_const('ENV', ENV.to_hash.merge('DAY_TO_SEND_FINAL_REMINDER' => Date.current.strftime(DateFormats::DAY_NAME_FULL)))
   end
 
   describe '.initialize' do


### PR DESCRIPTION
## Jira
[![VB-29](https://img.shields.io/badge/VB--29-Story-36B37E?style=flat-square&logo=jira)](https://clearboxdecisions.atlassian.net/browse/VB-29)
This PR standardizes the display format of time period date ranges across the UI, mailers, and ActiveAdmin to ensure consistency. It implements a unified format for displaying date ranges, specifically aligning the UI format to match the existing format used in mailers and ActiveAdmin (e.g., "Mar 30 - Apr 03, 2026"). The changes will involve updating the relevant components and templates where date ranges are rendered.




[VB-29]: https://clearboxdecisions.atlassian.net/browse/VB-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ