### PR TITLE
VB-43: Vertical GIFs (MP4 videos) are visually cropped on meme-selection and results pages

### DIFF
--- a/app/assets/stylesheets/gif.scss
+++ b/app/assets/stylesheets/gif.scss
@@ -73,12 +73,6 @@
     grid-template-columns: repeat(2, 1fr);
     height: 250px;
     }
-
-  video {
-    width: 100%;
-    height: 150px;
-    object-fit: cover;
-  }
 }
 
 .gif-card {

--- a/app/assets/stylesheets/gif.scss
+++ b/app/assets/stylesheets/gif.scss
@@ -179,7 +179,7 @@
 }
 
 .gif-container img {
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .gif-list img,
@@ -194,5 +194,5 @@
 }
 
 .gif-list img {
-  object-fit: cover;
+  object-fit: contain;
 }

--- a/app/assets/stylesheets/gif.scss
+++ b/app/assets/stylesheets/gif.scss
@@ -173,16 +173,32 @@
   margin-top: 6px;
   }
 
-.gif-container img {
-  width: 100%;
-  height: 100%;
-  min-height: 150px;
-  max-height: 180px;
-  object-fit: cover;
-  }
-
+.gif-container img,
 .gif-container video {
   width: 100%;
-  height: 150px;
+  height: 180px;
+  background: #111;
+}
+
+.gif-container video {
+  object-fit: contain;
+}
+
+.gif-container img {
+  object-fit: cover;
+}
+
+.gif-list img,
+.gif-list video {
+  width: 100%;
+  height: 180px;
+  background: #111;
+}
+
+.gif-list video {
+  object-fit: contain;
+}
+
+.gif-list img {
   object-fit: cover;
 }


### PR DESCRIPTION
## Jira
[![VB-43](https://img.shields.io/badge/VB--43-Bug-FF5630?style=flat-square&logo=jira)](https://clearboxdecisions.atlassian.net/browse/VB-43)
Adjust the container height for the MP4 videos on the meme-selection and results pages to match the standard height of 180px. Ensure that the videos are rendered correctly without cropping, by modifying the CSS styles associated with these containers to prevent truncation of the media content.




[VB-43]: https://clearboxdecisions.atlassian.net/browse/VB-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ